### PR TITLE
Matter over wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ ESPHome external component for matter support.
 It's still in early-development. Currently only the `on_off_switch`, `dimmer_switch`, `temperature_sensor`,
 `on_off_light` and `dimmable_light` matter endpoints are supported.
 
-The main limitation is that it currently isn't yet compatible with the `network` component. And since the
-`api` components requires `network`, there is no way to combine the api with matter. Incompatibility with `network`
-also means no `wifi`, `ethernet` or `openthread` can be configured. The thread TLV is passed to matter during commissioning
-and this is currently the only way to set up matter-over-thread. I think it will be possible to support matter-over-wifi and 
-matter-over-ethernet soon.
+# Progress
 
-I completely disabled wifi support to make it easier to implement matter-over-thread. This will also be fixed in the future.
+- matter-over-wifi: Working now! If you have configured `wifi` in the device config, matter announces itself via mDNS and you can commission it over-the-network.
+- matter-over-thread: The next step will be supporting the `openthread` component.
+- matter-over-ethernet: Not sure. But probably doesn't work yet.
+- commissioning over BLE: If no network (`wifi`, `openthread`, `ethernet`) is configured at all, matter falls back to 
+  BLE commissioning. This is how almost every matter device is commissioned. This mode is currently not compatible with
+  the `api` component since this checks network connectivity in a rather naive way that always fails if no network is
+  configured. This bug can only be fixed in ESPHome itself.
 
 # Compilation
 
@@ -22,6 +24,21 @@ esp32:
   framework:
     type: esp-idf
 ```
+
+# Commissioning
+
+Directly after flashing ESPHome (and after every restart), the commissioning code (starting with `MT:`) is printed in the logs:
+```
+[C][matter:293]: Matter:
+[C][matter:314]:   SetupQRCode: MT:Y.K904QI14-O992WI00
+[C][matter:315]:   QR URL: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT:Y.K904QI14-O992WI00
+[C][matter:323]:   Manual pairing code: 32552014321
+[C][matter:328]:   Commissioning window: open
+[C][matter:332]:   Fabrics: none
+```
+
+Copy the code and use this to commission the device. In python-matter-server you can commission the device with the `Commission existing device` option.
+Keep in mind that the commissioning window remains open for only 15 minutes. A restart of the device will re-open the window but only if it hasn't joined any fabrics yet.
 
 # Example config
 
@@ -45,6 +62,14 @@ external_components:
     refresh: 0s
 
 logger:
+  
+api:
+  
+network:
+  enable_ipv6: y
+  
+wifi:
+  ...
 
 matter:
   endpoints:
@@ -96,18 +121,3 @@ sensor:
     name: "Internal Temperature"
     id: internal_temp
 ```
-
-> [!WARNING]
-> **Endpoint IDs must stay stable.** Matter endpoint IDs are assigned by list order:
-> the first entry under `endpoints:` becomes endpoint 1, the second endpoint 2, and so on.
-> Other devices and controllers reference these IDs in their bindings and ACLs, so once the
-> device is commissioned, treat the list as append-only:
->
-> - **Never reorder or remove entries.** Removing a middle entry shifts every endpoint after
->   it down by one, breaking their bindings.
-> - **Never change the device type of an existing entry.** The endpoint keeps its ID but its
->   clusters change, which invalidates bindings targeting it.
-> - **Adding new entries at the end is safe.**
->
-> If you must restructure the list, re-commission the device afterwards and recreate its
-> bindings (and clean up stale ACL entries on bound devices).

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -168,8 +168,15 @@ async def to_code(config):
 
     enable_openthread = False
 
-    # CONFIG_USE_MINIMAL_MDNS=n makes matter use the espressif/mdns component which is also used by ESPHome.
-    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)  # connectedhomeip
+    # Use CHIP's built-in minimal mDNS stack. We cannot use CONFIG_USE_MINIMAL_MDNS=n (esp-mdns) because
+    # that path requires CHIP_DEVICE_CONFIG_ENABLE_WIFI=1, which is derived from
+    #   CHIP_DEVICE_CONFIG_ENABLE_WIFI = CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP | CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+    # Setting CONFIG_ENABLE_WIFI_STATION=n (required to prevent CHIP from driving esp_wifi and conflicting with
+    # ESPHome's wifi component) zeroes out CHIP_DEVICE_CONFIG_ENABLE_WIFI, which causes EspDnssdInit() in
+    # DnssdImpl.cpp to be compiled out. Without EspDnssdInit, HandleDnssdInit is never called, the advertiser
+    # state stays kInitializing, and all DNS-SD ops fail with CHIP_ERROR_INCORRECT_STATE.
+    # Minimal mDNS uses its own UDP socket and doesn't depend on CHIP_DEVICE_CONFIG_ENABLE_WIFI.
+    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", True)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
     add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_NUM_ADDRESSES", 6)

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -5,9 +5,10 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import light, sensor
 from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option, require_vfs_select
-from esphome.const import CONF_ID, CONF_LIGHT_ID, CONF_SENSOR_ID, Framework
+from esphome.const import CONF_ENABLE_IPV6, CONF_ID, CONF_LIGHT_ID, CONF_SENSOR_ID, Framework
 from esphome.core import CORE
 from esphome.coroutine import CoroPriority, coroutine_with_priority
+import esphome.final_validate as fv
 from esphome.helpers import write_file_if_changed
 
 from .kconfig import disable_unused_clusters
@@ -111,6 +112,17 @@ CONFIG_SCHEMA = cv.All(
     _require_vfs_select,  # TODO: Only needed when openthread is enabled
 )
 
+def _final_validate(_):
+    full_config = fv.full_config.get()
+    network_config = full_config.get("network", {})
+    if not network_config.get(CONF_ENABLE_IPV6, False):
+        raise cv.Invalid(
+            "OpenThread requires IPv6 to be enabled in the network component. "
+            "Please set `enable_ipv6: true` in the `network` configuration."
+        )
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
 # Wifi, ethernet and thread run at COMMUNICATION priority. Matter needs to start just after that and
 # NETWORK_SERVICES is the next CoroPriority so we choose that one.
 @coroutine_with_priority(CoroPriority.NETWORK_SERVICES)
@@ -183,11 +195,11 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
-        add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # chip core
 
         # TODO: fix the network implementation of ESPHome. Currently the network component is garbage and doesn't
         #   even support IPv6-only.
         # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
+        # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # chip core
 
     disable_unused_clusters()
 

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -168,15 +168,8 @@ async def to_code(config):
 
     enable_openthread = False
 
-    # Use CHIP's built-in minimal mDNS stack. We cannot use CONFIG_USE_MINIMAL_MDNS=n (esp-mdns) because
-    # that path requires CHIP_DEVICE_CONFIG_ENABLE_WIFI=1, which is derived from
-    #   CHIP_DEVICE_CONFIG_ENABLE_WIFI = CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP | CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    # Setting CONFIG_ENABLE_WIFI_STATION=n (required to prevent CHIP from driving esp_wifi and conflicting with
-    # ESPHome's wifi component) zeroes out CHIP_DEVICE_CONFIG_ENABLE_WIFI, which causes EspDnssdInit() in
-    # DnssdImpl.cpp to be compiled out. Without EspDnssdInit, HandleDnssdInit is never called, the advertiser
-    # state stays kInitializing, and all DNS-SD ops fail with CHIP_ERROR_INCORRECT_STATE.
-    # Minimal mDNS uses its own UDP socket and doesn't depend on CHIP_DEVICE_CONFIG_ENABLE_WIFI.
-    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", True)  # connectedhomeip
+    # CONFIG_USE_MINIMAL_MDNS=n makes matter use the espressif/mdns component which is also used by ESPHome.
+    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
     add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_NUM_ADDRESSES", 6)
@@ -187,6 +180,17 @@ async def to_code(config):
     # the ESPHome wifi component and enabling chip's Wi-Fi conflicts with this.
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
+
+    if ethernet_configured or wifi_configured:
+        # CONFIG_ENABLE_ETHERNET_TELEMETRY is just named completely wrong. Instead of what you would expect it to do,
+        # it just enables CHIP_DEVICE_CONFIG_ENABLE_ETHERNET which doesn't seem to break anything important. It makes
+        # connectedhomeip "think" it's connected via ethernet which prevent it from fucking with the wifi stack, while
+        # keeping important services such as DNS-SD enabled.
+        add_idf_sdkconfig_option("CONFIG_ENABLE_ETHERNET_TELEMETRY", True) # connectedhomeip
+        if not ethernet_configured:
+            add_idf_sdkconfig_option("GPIO_RANGE_MAX", 10) # connectedhomeip TODO: only set if there is no default?
+            add_idf_sdkconfig_option("ETH_MDC_GPIO", 0) # connectedhomeip
+            add_idf_sdkconfig_option("ETH_MDIO_GPIO", 0) # connectedhomeip
 
     # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
     add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", enable_openthread)  # esp-matter
@@ -208,7 +212,7 @@ async def to_code(config):
 
     add_idf_sdkconfig_option("CONFIG_ENABLE_CHIPOBLE", not any_network_configured)  # connectedhomeip
     if any_network_configured:
-        cg.add_define("MATTER_RENDEZVOUS_ON_NETWORK")
+        cg.add_define("MATTER_RENDEZVOUS_ON_NETWORK") # esphome-matter
     else:
         # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
         # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -12,18 +12,11 @@ from esphome.helpers import write_file_if_changed
 
 from .kconfig import disable_unused_clusters
 
+from .const import *
+
 CODEOWNERS = ["@DavidvtWout"]
 
-# DEPENDENCIES = ["network"]
-
-CONF_DISCRIMINATOR = "discriminator"
-CONF_PASSCODE = "passcode"
-CONF_ENDPOINTS = "endpoints"
-CONF_ON_OFF_SWITCH = "on_off_switch"
-CONF_DIMMER_SWITCH = "dimmer_switch"
-CONF_TEMPERATURE_SENSOR = "temperature_sensor"
-CONF_ON_OFF_LIGHT = "on_off_light"
-CONF_DIMMABLE_LIGHT = "dimmable_light"
+AUTO_LOAD = ["network"]
 
 # Matter spec section 5.1.7.1: these passcodes are explicitly forbidden.
 _FORBIDDEN_PASSCODES = {
@@ -190,8 +183,11 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
         add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # chip core
+
+        # TODO: fix the network implementation of ESPHome. Currently the network component is garbage and doesn't
+        #   even support IPv6-only.
+        # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
 
     disable_unused_clusters()
 

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -183,6 +183,7 @@ async def to_code(config):
 
     # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
     add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", enable_openthread)  # esp-matter
+    add_idf_sdkconfig_option("CONFIG_ENABLE_MATTER_OVER_THREAD", enable_openthread)  # connectedhomeip
     if enable_openthread:
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
@@ -198,8 +199,10 @@ async def to_code(config):
         # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
         # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # connectedhomeip
 
-    add_idf_sdkconfig_option("CONFIG_ENABLE_CHIPOBLE", not any_network_configured)
-    if not any_network_configured:
+    add_idf_sdkconfig_option("CONFIG_ENABLE_CHIPOBLE", not any_network_configured)  # connectedhomeip
+    if any_network_configured:
+        cg.add_define("MATTER_RENDEZVOUS_ON_NETWORK")
+    else:
         # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
         # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be
         # commissioned as matter-over-thread or matter-over-wifi device depending on the hardware capabilities of the

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -117,12 +117,12 @@ def _final_validate(_):
     network_config = full_config.get("network", {})
     if not network_config.get(CONF_ENABLE_IPV6, False):
         raise cv.Invalid(
-            "matter-over-thread requires IPv6 to be enabled in the network component. "
+            "Matter requires IPv6 to be enabled in the network component (technically IPv4-only matter-over-wifi"
+            "should be possible but the spec forbids this and the connectedhomeip project doesn't support this). "
             "Please set `enable_ipv6: true` in the `network` configuration."
         )
 
-# TODO: only for matter-over-thread
-# FINAL_VALIDATE_SCHEMA = _final_validate
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 # Wifi, ethernet and thread run at COMMUNICATION priority. Matter needs to start just after that and
 # NETWORK_SERVICES is the next CoroPriority so we choose that one.
@@ -187,7 +187,7 @@ async def to_code(config):
 
     # These are connectedhomeip specific flags
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False) # connectedhomeip
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", wifi_configured)  # connectedhomeip
+    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
 
     if enable_openthread:
         add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", True)

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -181,17 +181,6 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
 
-    if ethernet_configured or wifi_configured:
-        # CONFIG_ENABLE_ETHERNET_TELEMETRY is just named completely wrong. Instead of what you would expect it to do,
-        # it just enables CHIP_DEVICE_CONFIG_ENABLE_ETHERNET which doesn't seem to break anything important. It makes
-        # connectedhomeip "think" it's connected via ethernet which prevent it from fucking with the wifi stack, while
-        # keeping important services such as DNS-SD enabled.
-        add_idf_sdkconfig_option("CONFIG_ENABLE_ETHERNET_TELEMETRY", True) # connectedhomeip
-        if not ethernet_configured:
-            add_idf_sdkconfig_option("GPIO_RANGE_MAX", 10) # connectedhomeip TODO: only set if there is no default?
-            add_idf_sdkconfig_option("ETH_MDC_GPIO", 0) # connectedhomeip
-            add_idf_sdkconfig_option("ETH_MDIO_GPIO", 0) # connectedhomeip
-
     # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
     add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", enable_openthread)  # esp-matter
     add_idf_sdkconfig_option("CONFIG_ENABLE_MATTER_OVER_THREAD", enable_openthread)  # connectedhomeip

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -172,6 +172,10 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
+    add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_NUM_ADDRESSES", 6)
+    add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
+    add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
+
     # These are connectedhomeip specific flags and must both be set to False since Wi-Fi is already managed by
     # the ESPHome wifi component and enabling chip's Wi-Fi conflicts with this.
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
@@ -187,10 +191,6 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CONSOLE_ENABLE", False)
         add_idf_sdkconfig_option("CONFIG_ENABLE_MATTER_OVER_THREAD", True)
         add_idf_sdkconfig_option("CONFIG_ENABLE_CHIP_DATA_MODEL", True)
-
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_NUM_ADDRESSES", 6)
-        add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
-        add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
 
         # TODO: fix the network implementation of ESPHome. Currently the network component is garbage and doesn't

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -113,16 +113,16 @@ CONFIG_SCHEMA = cv.All(
 )
 
 def _final_validate(_):
-    # TODO: technically matter is able to operate over IPv4 so only check ipv6 if needed.
     full_config = fv.full_config.get()
     network_config = full_config.get("network", {})
     if not network_config.get(CONF_ENABLE_IPV6, False):
         raise cv.Invalid(
-            "OpenThread requires IPv6 to be enabled in the network component. "
+            "matter-over-thread requires IPv6 to be enabled in the network component. "
             "Please set `enable_ipv6: true` in the `network` configuration."
         )
 
-FINAL_VALIDATE_SCHEMA = _final_validate
+# TODO: only for matter-over-thread
+# FINAL_VALIDATE_SCHEMA = _final_validate
 
 # Wifi, ethernet and thread run at COMMUNICATION priority. Matter needs to start just after that and
 # NETWORK_SERVICES is the next CoroPriority so we choose that one.
@@ -166,8 +166,7 @@ async def to_code(config):
     wifi_configured = "wifi" in CORE.loaded_integrations
     any_network_configured = ethernet_configured or openthread_configured or wifi_configured
 
-    enable_openthread = True
-    enable_wifi = False
+    enable_openthread = False
 
     if not any_network_configured:
         # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
@@ -188,7 +187,7 @@ async def to_code(config):
 
     # These are connectedhomeip specific flags
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False) # connectedhomeip
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", enable_wifi)  # connectedhomeip
+    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", wifi_configured)  # connectedhomeip
 
     if enable_openthread:
         add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", True)

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -198,6 +198,7 @@ async def to_code(config):
         # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
         # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # connectedhomeip
 
+    add_idf_sdkconfig_option("CONFIG_ENABLE_CHIPOBLE", not any_network_configured)
     if not any_network_configured:
         # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
         # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -113,6 +113,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 def _final_validate(_):
+    # TODO: technically matter is able to operate over IPv4 so only check ipv6 if needed.
     full_config = fv.full_config.get()
     network_config = full_config.get("network", {})
     if not network_config.get(CONF_ENABLE_IPV6, False):
@@ -159,27 +160,35 @@ async def to_code(config):
     if CONF_PASSCODE in config:
         cg.add_define("MATTER_PASSCODE", config[CONF_PASSCODE])
 
-    # has_wifi = "wifi" in CORE.loaded_integrations
-    # has_ethernet = "ethernet" in CORE.loaded_integrations
-    # has_openthread = "openthread" in CORE.loaded_integrations
 
-    enable_ble = True
+    ethernet_configured = "ethernet" in CORE.loaded_integrations
+    openthread_configured = "openthread" in CORE.loaded_integrations
+    wifi_configured = "wifi" in CORE.loaded_integrations
+    any_network_configured = ethernet_configured or openthread_configured or wifi_configured
+
     enable_openthread = True
     enable_wifi = False
 
-    # TODO: use CORE.data?
-    if enable_ble:
+    if not any_network_configured:
+        # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
+        # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be
+        # commissioned as matter-over-thread or matter-over-wifi device depending on the hardware capabilities of the
+        # device. If the device supports both, it can be commissioned in either mode.
+
+        # TODO: use CORE.data?
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_BT_BLUEDROID_ENABLED", False)
         add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLE_CONN_REATTEMPT", False)
         # TODO: set USE_BLE_ONLY_FOR_COMMISSIONING to false if other esphome components need it?
 
+    # CONFIG_USE_MINIMAL_MDNS=n makes matter use the espressif/mdns component which is also used by ESPHome.
     add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", enable_wifi)
+    # These are connectedhomeip specific flags
+    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False) # connectedhomeip
+    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", enable_wifi)  # connectedhomeip
 
     if enable_openthread:
         add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", True)
@@ -199,7 +208,7 @@ async def to_code(config):
         # TODO: fix the network implementation of ESPHome. Currently the network component is garbage and doesn't
         #   even support IPv6-only.
         # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
-        # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # chip core
+        # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # connectedhomeip
 
     disable_unused_clusters()
 

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -168,29 +168,18 @@ async def to_code(config):
 
     enable_openthread = False
 
-    if not any_network_configured:
-        # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
-        # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be
-        # commissioned as matter-over-thread or matter-over-wifi device depending on the hardware capabilities of the
-        # device. If the device supports both, it can be commissioned in either mode.
-
-        # TODO: use CORE.data?
-        add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
-        add_idf_sdkconfig_option("CONFIG_BT_BLUEDROID_ENABLED", False)
-        add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLED", True)
-        add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLE_CONN_REATTEMPT", False)
-        # TODO: set USE_BLE_ONLY_FOR_COMMISSIONING to false if other esphome components need it?
-
     # CONFIG_USE_MINIMAL_MDNS=n makes matter use the espressif/mdns component which is also used by ESPHome.
-    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)
+    add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
-    # These are connectedhomeip specific flags
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False) # connectedhomeip
+    # These are connectedhomeip specific flags and must both be set to False since Wi-Fi is already managed by
+    # the ESPHome wifi component and enabling chip's Wi-Fi conflicts with this.
+    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
     add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
 
+    # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
+    add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", enable_openthread)  # esp-matter
     if enable_openthread:
-        add_idf_sdkconfig_option("CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", True)
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS_CLIENT", True)
@@ -209,11 +198,23 @@ async def to_code(config):
         # add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", False)
         # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # connectedhomeip
 
+    if not any_network_configured:
+        # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
+        # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be
+        # commissioned as matter-over-thread or matter-over-wifi device depending on the hardware capabilities of the
+        # device. If the device supports both, it can be commissioned in either mode.
+
+        # TODO: use CORE.data?
+        add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
+        add_idf_sdkconfig_option("CONFIG_BT_BLUEDROID_ENABLED", False)
+        add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLED", True)
+        add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLE_CONN_REATTEMPT", False)
+        # TODO: set USE_BLE_ONLY_FOR_COMMISSIONING to false if other esphome components need it?
+        # TODO: stop api from restarting device in commissioning mode?
+
     disable_unused_clusters()
 
     # TODO: ENABLE_ESP32_FACTORY_DATA_PROVIDER?
-
-    # TODO: stop api from restarting device in commissioning mode?
 
     # CHIP's mbedTLS crypto backend calls mbedtls_hkdf() (CHIPCryptoPALmbedTLS.cpp).
     # ESP-IDF's mbedTLS disables HKDF by default; enabling this compiles mbedtls/hkdf.c

--- a/components/matter/const.py
+++ b/components/matter/const.py
@@ -1,0 +1,8 @@
+CONF_DISCRIMINATOR = "discriminator"
+CONF_PASSCODE = "passcode"
+CONF_ENDPOINTS = "endpoints"
+CONF_ON_OFF_SWITCH = "on_off_switch"
+CONF_DIMMER_SWITCH = "dimmer_switch"
+CONF_TEMPERATURE_SENSOR = "temperature_sensor"
+CONF_ON_OFF_LIGHT = "on_off_light"
+CONF_DIMMABLE_LIGHT = "dimmable_light"

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -4,6 +4,7 @@
 #include "matter_component.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
+#include "esphome/components/network/util.h"
 
 #include <cinttypes>
 #include <cstring>
@@ -235,6 +236,24 @@ void MatterComponent::setup() {
   this->register_endpoint_callbacks_();
 }
 
+void MatterComponent::loop() {
+  // CHIP re-advertises DNS-SD (the _matterc._udp / _matter._tcp records) only on
+  // kDnssdInitialized / kDnssdRestartNeeded events. On ESP32 those are posted by
+  // CHIP's WiFi connectivity manager when the station gets an IP — but that code
+  // is compiled out (CONFIG_ENABLE_WIFI_STATION=n) because ESPHome owns the WiFi
+  // driver. So CHIP never learns the ESPHome-managed interface came up and never
+  // advertises. We bridge that here: on the network up-edge, post the same event
+  // the WiFi manager would have, which drives DnssdServer::StartServer().
+  bool connected = network::is_connected();
+  if (connected && !this->network_was_connected_) {
+    ESP_LOGD(TAG, "Network up; requesting Matter DNS-SD (re)advertise");
+    chip::DeviceLayer::ChipDeviceEvent event;
+    event.Type = chip::DeviceLayer::DeviceEventType::kDnssdRestartNeeded;
+    chip::DeviceLayer::PlatformMgr().PostEventOrDie(&event);
+  }
+  this->network_was_connected_ = connected;
+}
+
 void MatterComponent::factory_reset() {
   ESP_LOGW(TAG, "Matter factory reset. Erasing fabric data and rebooting");
   for (const char *ns : {"chip-config", "chip-counters", "CHIP_KVS"}) {
@@ -260,7 +279,11 @@ void MatterComponent::dump_config() {
   payload.vendorID = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
   payload.productID = CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID;
   payload.commissioningFlow = chip::CommissioningFlow::kStandard;
+#ifdef MATTER_RENDEZVOUS_ON_NETWORK
+  payload.rendezvousInformation.SetValue(chip::RendezvousInformationFlag::kOnNetwork);
+#else
   payload.rendezvousInformation.SetValue(chip::RendezvousInformationFlag::kBLE);
+#endif
   payload.discriminator.SetLongValue(this->discriminator_);
   payload.setUpPINCode = this->passcode_;
 

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <nvs.h>
 #include <esp_random.h>
+#include <esp_event.h>
+#include <esp_netif.h>
 
 #include <app/server/Server.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -130,6 +132,21 @@ namespace esphome::matter {
 
 MatterComponent *global_matter_component = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+static void on_got_ipv6(void *, esp_event_base_t, int32_t, void *event_data) {
+  // Only re-advertise for global unicast (2000::/3), not link-local (fe80::/10).
+  // Link-local addresses are in every AAAA response anyway; re-advertising for them
+  // just adds noise and may cause commissioners to try an unroutable address first.
+  auto *data = static_cast<ip_event_got_ip6_t *>(event_data);
+  const uint8_t *addr = reinterpret_cast<const uint8_t *>(data->ip6_info.ip.addr);
+  bool is_global = (addr[0] & 0xE0) == 0x20;  // 2000::/3
+  if (!is_global)
+    return;
+  ESP_LOGD(TAG, "Got global IPv6 address; requesting Matter DNS-SD re-advertise");
+  chip::DeviceLayer::ChipDeviceEvent event;
+  event.Type = chip::DeviceLayer::DeviceEventType::kDnssdRestartNeeded;
+  chip::DeviceLayer::PlatformMgr().PostEventOrDie(&event);
+}
+
 static void event_callback(const ChipDeviceEvent *event, intptr_t arg) {
   switch (event->Type) {
     case chip::DeviceLayer::DeviceEventType::kInterfaceIpAddressChanged:
@@ -222,6 +239,11 @@ void MatterComponent::setup() {
   //  };
   set_openthread_platform_config(&ot_config);
 #endif
+
+  // Re-advertise DNS-SD when an IPv6 address is assigned (SLAAC may complete after WiFi up).
+  // Without this, the first mDNS announcement may only contain an A record, and the matter
+  // controller discovers the device as IPv4-only and may fail to connect.
+  esp_event_handler_register(IP_EVENT, IP_EVENT_GOT_IP6, on_got_ipv6, nullptr);
 
   /* Matter start */
   esp_err_t err = esp_matter::start(event_callback);

--- a/components/matter/matter_component.h
+++ b/components/matter/matter_component.h
@@ -15,6 +15,7 @@ namespace esphome::matter {
 class MatterComponent : public Component {
  public:
   void setup() override;
+  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
   void factory_reset();
@@ -51,6 +52,9 @@ class MatterComponent : public Component {
 
   uint16_t discriminator_{0};
   uint32_t passcode_{0};
+  // Tracks network connectivity so we can tell CHIP to (re)advertise DNS-SD when
+  // the ESPHome-managed interface comes up (see loop() in matter_component.cpp).
+  bool network_was_connected_{false};
   std::vector<MatterOnOffSwitch> on_off_switches_;
   std::vector<MatterDimmerSwitch> dimmer_switches_;
 #ifdef USE_SENSOR

--- a/components/matter/matter_dnssd.cpp
+++ b/components/matter/matter_dnssd.cpp
@@ -1,0 +1,163 @@
+// matter_dnssd.cpp
+//
+// Linker-override replacements for the chip::Dnssd::ChipDnsd*() platform functions.
+//
+// Why this file exists
+// --------------------
+// connectedhomeip gates its ESP32 DNS-SD backend (EspDnssdInit / EspDnssdPublishService etc.)
+// behind #if CHIP_DEVICE_CONFIG_ENABLE_WIFI || CHIP_DEVICE_CONFIG_ENABLE_ETHERNET.
+// We set both to 0 because:
+//   - CONFIG_ENABLE_WIFI_STATION=n: required to prevent CHIP from driving esp_wifi and racing
+//     ESPHome's wifi component.
+//   - CONFIG_ENABLE_ETHERNET_TELEMETRY=n: on ESP32-C6, enabling it crashes kconfgen because
+//     CHIP's Kconfig omits GPIO_RANGE_MAX defaults for that target.
+//
+// With both flags 0, all ChipDnsd*() functions in DnssdImpl.cpp compile to no-ops. This file
+// provides strong-symbol replacements that call ESP-IDF's mdns component directly, bypassing
+// the gates. The linker prefers definitions from application .o files over archive members,
+// so these replace the CHIP library's no-ops without touching any CHIP source.
+//
+// We deliberately omit the mdns_hostname_set() call that EspDnssdPublishService() makes —
+// Matter services are registered under ESPHome's current hostname, keeping them consistent with
+// _esphomelib._tcp. Matter commissioners follow SRV → A/AAAA regardless of hostname text.
+
+#include "esphome/core/defines.h"
+#ifdef USE_MATTER
+
+#include <mdns.h>
+
+#include <lib/dnssd/platform/Dnssd.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace Dnssd {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static const char * GetProtocol(DnssdServiceProtocol protocol)
+{
+    return protocol == DnssdServiceProtocol::kDnssdProtocolTcp ? "_tcp" : "_udp";
+}
+
+// ---------------------------------------------------------------------------
+// Init / Shutdown
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
+{
+    // mdns_init() is idempotent — ESPHome's mdns component already called it.
+    esp_err_t err = mdns_init();
+    if (err != ESP_OK)
+    {
+        ChipLogError(DeviceLayer, "mdns_init failed: %s", esp_err_to_name(err));
+        initCallback(context, CHIP_ERROR_INTERNAL);
+        return CHIP_ERROR_INTERNAL;
+    }
+    initCallback(context, CHIP_NO_ERROR);
+    return CHIP_NO_ERROR;
+}
+
+void ChipDnssdShutdown() {}
+
+// ---------------------------------------------------------------------------
+// Advertising
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    mdns_txt_item_t * items = nullptr;
+    esp_err_t espError = ESP_OK;
+    const char * proto = GetProtocol(service->mProtocol);
+
+    // Build TXT record array.
+    VerifyOrExit(service->mTextEntrySize <= UINT8_MAX, error = CHIP_ERROR_INVALID_ARGUMENT);
+    if (service->mTextEntries && service->mTextEntrySize > 0)
+    {
+        items = static_cast<mdns_txt_item_t *>(
+            chip::Platform::MemoryCalloc(service->mTextEntrySize, sizeof(mdns_txt_item_t)));
+        VerifyOrExit(items != nullptr, error = CHIP_ERROR_NO_MEMORY);
+        for (size_t i = 0; i < service->mTextEntrySize; i++)
+        {
+            items[i].key   = service->mTextEntries[i].mKey;
+            items[i].value = reinterpret_cast<const char *>(service->mTextEntries[i].mData);
+        }
+    }
+
+    // Remove all instances of this service type — CHIP generates a new random instance name
+    // on every re-advertise, so checking by instance name leaves stale entries behind.
+    while (mdns_service_exists(service->mType, proto, nullptr))
+        mdns_service_remove(service->mType, proto);
+
+    espError = mdns_service_add(service->mName, service->mType, proto, service->mPort,
+                                items, service->mTextEntrySize);
+    VerifyOrExit(espError == ESP_OK, error = CHIP_ERROR_INTERNAL);
+
+    for (size_t i = 0; i < service->mSubTypeSize; i++)
+    {
+        esp_err_t subtypeErr = mdns_service_subtype_add_for_host(
+            service->mName, service->mType, proto, nullptr, service->mSubTypes[i]);
+        if (subtypeErr != ESP_OK)
+        {
+            ChipLogError(DeviceLayer, "Failed to add mDNS subtype %s: %s",
+                         service->mSubTypes[i], esp_err_to_name(subtypeErr));
+        }
+    }
+
+exit:
+    chip::Platform::MemoryFree(items);
+    // ESP32 platform publishes synchronously; callback is not invoked (matches EspDnssdPublishService).
+    return error;
+}
+
+CHIP_ERROR ChipDnssdRemoveServices()
+{
+    while (mdns_service_exists("_matter", "_tcp", nullptr))
+        mdns_service_remove("_matter", "_tcp");
+    while (mdns_service_exists("_matterc", "_udp", nullptr))
+        mdns_service_remove("_matterc", "_udp");
+    while (mdns_service_exists("_matterd", "_udp", nullptr))
+        mdns_service_remove("_matterd", "_udp");
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDnssdFinalizeServiceUpdate()
+{
+    return CHIP_NO_ERROR;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery (controller-side) — not needed; return harmless values
+// ---------------------------------------------------------------------------
+
+CHIP_ERROR ChipDnssdBrowse(const char *, DnssdServiceProtocol, chip::Inet::IPAddressType,
+                           chip::Inet::InterfaceId, DnssdBrowseCallback, void *, intptr_t *)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDnssdStopBrowse(intptr_t)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipDnssdResolve(DnssdService *, chip::Inet::InterfaceId, DnssdResolveCallback, void *)
+{
+    return CHIP_NO_ERROR;
+}
+
+void ChipDnssdResolveNoLongerNeeded(const char *) {}
+
+CHIP_ERROR ChipDnssdReconfirmRecord(const char *, chip::Inet::IPAddress, chip::Inet::InterfaceId)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+} // namespace Dnssd
+} // namespace chip
+
+#endif // USE_MATTER

--- a/docs/dev/dnssd-wifi-ownership.md
+++ b/docs/dev/dnssd-wifi-ownership.md
@@ -1,0 +1,125 @@
+# DNS-SD / mDNS under ESPHome WiFi ownership
+
+## The problem
+
+Matter commissioning over Wi-Fi requires the device to advertise `_matterc._udp`
+(and after commissioning `_matter._tcp`) via mDNS. When those records are absent, any
+Matter controller that tries to commission on-network will simply never find the device.
+
+In a normal esp-matter project this works out of the box. In an ESPHome project it
+doesn't, because of two interacting constraints:
+
+1. **ESPHome owns the Wi-Fi driver.** CHIP's `ConnectivityManagerImpl_WiFi` must be
+   compiled out (`CONFIG_ENABLE_WIFI_STATION=n`, `CONFIG_ENABLE_WIFI_AP=n`); otherwise
+   it calls `esp_wifi_start()` / `esp_wifi_connect()` and races ESPHome's wifi
+   component, producing `ESP_ERR_WIFI_STOP_STATE` and an endless "Restarting adapter"
+   loop that prevents the interface from ever associating.
+
+2. **CHIP's DNS-SD backend is gated by connectivity flags.** All real implementations
+   of `ChipDnsd*()` in `connectedhomeip/src/platform/ESP32/DnssdImpl.cpp` are inside
+   `#if CHIP_DEVICE_CONFIG_ENABLE_WIFI || CHIP_DEVICE_CONFIG_ENABLE_ETHERNET`. With
+   both flags at 0, every function compiles to a no-op or returns
+   `CHIP_ERROR_INCORRECT_STATE`. CHIP's `DiscoveryImplPlatform` advertiser stays in
+   `kInitializing` forever.
+
+The two constraints together form a closed loop: disabling CHIP's WiFi manager (required
+for ESPHome compatibility) also disables the only DNS-SD backend that works at runtime.
+
+---
+
+## Approaches tried and why they failed
+
+### 1. `CONFIG_USE_MINIMAL_MDNS=y`
+
+CHIP has a built-in ("minimal") mDNS implementation that doesn't depend on
+`CHIP_DEVICE_CONFIG_ENABLE_WIFI`. Enable it and the flag gate disappears.
+
+**Why it fails:** CHIP's minimal mDNS tries to bind UDP port 5353. ESP-IDF's
+`espressif/mdns` component (used by ESPHome) already holds that socket, and it binds
+without `SOF_REUSEADDR` (`mdns_networking_lwip.c:43`). The second bind returns LwIP
+`ERR_USE` (value 8), which bubbles up as:
+
+- `0x3000008` — `CHIP_ERROR` range `kLwIP` (byte `0x03`) + LwIP error value 8
+- `0x46` = `CHIP_ERROR_NO_ENDPOINT` — cascade from the bind failure
+
+The port conflict is structural; there is no socket option that fixes it without
+modifying ESP-IDF mdns source.
+
+### 2. `CONFIG_ENABLE_ETHERNET_TELEMETRY=y`
+
+Setting this Kconfig flag sets `CHIP_DEVICE_CONFIG_ENABLE_ETHERNET=1`, which unblocks
+the `#if` gate in `DnssdImpl.cpp` and makes `EspDnssdInit` / `EspDnssdPublishService`
+compile as real code — without requiring CHIP to own Wi-Fi.
+
+**Why it fails on ESP32-C6:** CHIP's Kconfig (`config/esp32/components/chip/Kconfig`)
+defines `GPIO_RANGE_MAX` as a range-constrained integer with `depends on
+ENABLE_ETHERNET_TELEMETRY`, but only provides `default` values for ESP32, S2, C3, S3,
+and H2. ESP32-C6 has no matching `default`. When `ENABLE_ETHERNET_TELEMETRY=y` on
+ESP32-C6, the symbol is active but `str_value = ''`. kconfgen's `write_json_menus()`
+then hits `int('', 10)` → `ValueError: invalid literal for int() with base 10: ''`.
+This crash is in kconfgen's Kconfig tree introspection (menu serialization), not user
+value resolution, so setting `GPIO_RANGE_MAX` in `sdkconfig.defaults` or via
+`add_idf_sdkconfig_option()` does not help — the crash happens before any user values
+are read.
+
+Additionally, even if the build succeeded, `EspDnssdPublishService()` calls
+`mdns_hostname_set(service->mHostName)` where `mHostName` is CHIP's MAC-derived
+hostname. This would silently overwrite ESPHome's configured device hostname for all
+mDNS services (including `_esphomelib._tcp`), making them advertise under the wrong
+name.
+
+And `ESPEthernetDriver::Init()` (compiled in by the same flag) attempts to initialize
+an IP101 PHY chip via GPIO (MDC/MDIO/RST pins). ESP32-C6 has no RMII Ethernet MAC
+peripheral; this would fail or corrupt GPIO state.
+
+---
+
+## The solution: linker-override DNS-SD
+
+The linker prefers strong-symbol definitions from application `.o` files over weak
+symbols or archive members. CHIP links its platform libraries as `--whole-archive`
+archives, but application-layer `.o` files take precedence for symbols defined in both
+places.
+
+`matter_dnssd.cpp` (compiled by PlatformIO's SCons pass as part of the `src`
+component) defines all `chip::Dnssd::ChipDnsd*()` functions as real implementations
+that call `espressif/mdns` directly. At link time the linker picks these over the
+no-op stubs in `DnssdImpl.cpp`, bypassing all Kconfig gates without touching any CHIP
+source and without any sdkconfig changes.
+
+### Key design decisions
+
+**No `mdns_hostname_set()` call.** The original `EspDnssdPublishService()` clobbers
+the device hostname. We deliberately omit this; Matter services are registered under
+ESPHome's hostname, keeping `_matterc._udp` and `_esphomelib._tcp` consistent.
+
+**`mdns_init()` is idempotent.** ESPHome's mdns component already called it; calling
+it again in `ChipDnssdInit` is safe and required by the CHIP platform API.
+
+**Remove by type, not instance name.** CHIP generates a fresh random 64-bit instance
+name (e.g. `19CD1A9C30FBC089`) on every re-advertise cycle. Removing only the specific
+instance name before re-adding leaves stale instances from prior cycles in the mDNS
+responder. `ChipDnssdPublishService` instead removes all instances of the service type
+(`while mdns_service_exists(...) mdns_service_remove(...)`) before adding the new one.
+
+**Subtypes must be registered explicitly.** Matter controllers do not browse
+`_matterc._udp` directly — they query the discriminator subtype
+`_L<discriminator>._sub._matterc._udp.local.` (and `_S<short>`, `_CM`, `_V<vendor>`).
+CHIP passes these in `service->mSubTypes`. Without calling
+`mdns_service_subtype_add_for_host()` for each, the device is invisible to the
+commissioner even though `_matterc._udp` is correctly advertised. This was the last
+remaining commissioning blocker.
+
+**Network up-edge bridge.** With CHIP's WiFi manager compiled out, CHIP never
+receives the IP-up event that normally drives `DnssdServer::StartServer()`.
+`MatterComponent::loop()` watches `network::is_connected()` and on the rising edge
+posts `kDnssdRestartNeeded` via `PlatformMgr().PostEventOrDie()`, which triggers
+the same re-advertise path.
+
+**Global IPv6 re-advertisement.** The first mDNS announcement goes out as soon as WiFi
+connects, before IPv6 SLAAC completes, so the initial records contain only the A
+record. `MatterComponent::setup()` registers an `IP_EVENT_GOT_IP6` handler that posts
+another `kDnssdRestartNeeded` once a global unicast address (`2000::/3`) is assigned,
+ensuring the updated announcement includes the AAAA record. Link-local (`fe80::/10`)
+assignments are ignored — they trigger the event first but are not usable without
+interface scope information on the commissioner side.


### PR DESCRIPTION
`connectedhomeip` (the matter library) really doesn't want to be integrated into other projects... The goal of this PR is get `esphome-matter` to work together with the `wifi` component and support on-network provisioning. The `CONFIG_ENABLE_WIFI_AP` and `CONFIG_ENABLE_WIFI_STATION` need to be disabled because otherwise `connectedhomeip` starts to manage the wifi radio which obviously doesn't work if the wifi component does the same. But disabling both of these options also disables important services such as DNS-SD. My current approach is to enable `CONFIG_ENABLE_ETHERNET_TELEMETRY` (which doesn't at all what the name makes you think it does, it's basically a flag that enables ethernet support) to prevent these services from being disabled. But that also breaks things of course... Because now `connectedhomeip` wants to manage an ethernet adapter that doesn't exist...

Solution: re-implemented the dns-sd service