### PR TITLE
Matter-over-thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 ESPHome external component adding Matter 1.5 support via Espressif's [esp-matter 1.5.1](https://components.espressif.com/components/espressif/esp_matter/versions/1.5.1).
 
 > [!WARNING]
-> This project is still in early-development so don't expect a perfectly working setup. matter-over-wifi is now sort
-> of working but only very few matter endpoints are supported yet. Currently only the `on_off_switch`, `dimmer_switch`,
-> `temperature_sensor`, `on_off_light` and `dimmable_light` endpoints are supported.
-> I will first focus on matter-over-thread and matter-over-ethernet and getting everything stable before I add useful features.
+> This project is still in early-development so don't expect a perfectly working setup. Both matter-over-wifi and
+> matter-over-thread are now working. It's possible to commission a device to a matter controller but some features such
+> as binding are still missing.
+> 
+> Only very few Matter endpoints are supported yet. Currently only the `on_off_switch`, `dimmer_switch`, `temperature_sensor`,
+> `on_off_light` and `dimmable_light` endpoints are supported. More will be added soon!
+> 
+> Also, esphome-matter heavily relies on platformio now. So while esphome is moving to the esp-idf toolchain, this is
+> not yet supported by esphome-matter.
 
 # Contributing
 
@@ -15,9 +20,9 @@ Even if you have no experience with any of these: just building the project and 
 
 # Progress
 
-- matter-over-wifi: Working now! If you have configured `wifi` in the device config, matter announces itself via mDNS and you can commission it over-the-network.
-- matter-over-thread: The next step will be supporting the `openthread` component.
-- matter-over-ethernet: Not sure. But probably doesn't work yet.
+- matter-over-wifi: If you have configured `wifi` in the device config, matter announces itself via mDNS and you can commission it on-network.
+- matter-over-thread: When the `openthread` component is configured, `esphome-matter` attaches to the OpenThread stack and SRP client. On-network commissioning is working.
+- matter-over-ethernet: Not sure... If you have a device with ethernet port, please report if this works!
 - commissioning over BLE: If no network (`wifi`, `openthread`, `ethernet`) is configured at all, matter falls back to 
   BLE commissioning. This is how almost every matter device is commissioned. This mode is currently not compatible with
   the `api` component since this checks network connectivity in a rather naive way that always fails if no network is
@@ -30,12 +35,12 @@ See the [issue page](https://github.com/DavidvtWout/esphome-matter/issues) for m
 
 Directly after flashing ESPHome (and after every restart), the commissioning code (starting with `MT:`) is printed in the logs:
 ```
-[C][matter:293]: Matter:
-[C][matter:314]:   SetupQRCode: MT:Y.K904QI14-O992WI00
-[C][matter:315]:   QR URL: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT:Y.K904QI14-O992WI00
-[C][matter:323]:   Manual pairing code: 32552014321
-[C][matter:328]:   Commissioning window: open
-[C][matter:332]:   Fabrics: none
+[C][matter]: Matter:
+[C][matter]:   SetupQRCode: MT:Y.K904QI14-O992WI00
+[C][matter]:   QR URL: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT:Y.K904QI14-O992WI00
+[C][matter]:   Manual pairing code: 32552014321
+[C][matter]:   Commissioning window: open
+[C][matter]:   Fabrics: none
 ```
 
 Copy the code and use this to commission the device. In python-matter-server you can commission the device with the `Commission existing device` option.
@@ -46,10 +51,8 @@ Keep in mind that the commissioning window remains open for only 15 minutes. A r
 ```yaml
 esphome:
   name: matter-device
-  friendly_name: Matter Device
 
 esp32:
-  # Native esp-idf isn't supported yet.
   toolchain: platformio
   variant: ESP32C6 # Set to your variant
   framework:
@@ -65,7 +68,11 @@ api:
 network:
   enable_ipv6: true
   
+# Either:
 wifi:
+  ...
+# Or:
+openthread:
   ...
 
 matter:
@@ -88,14 +95,11 @@ binary_sensor:
         input: true
       inverted: true
     on_click:
-      matter.turn_on:
-        id: dimmer_endpoint
+      matter.turn_on: dimmer_endpoint
     on_press:
-      matter.dim_up:
-        id: dimmer_endpoint
+      matter.dim_up: dimmer_endpoint
     on_release:
-      matter.dim_stop:
-        id: dimmer_endpoint
+      matter.dim_stop: dimmer_endpoint
   - name: "Button down"
     id: button_down
     platform: gpio
@@ -106,14 +110,11 @@ binary_sensor:
         input: true
       inverted: true
     on_click:
-      matter.turn_off:
-        id: dimmer_endpoint
+      matter.turn_off: dimmer_endpoint
     on_press:
-      matter.dim_down:
-        id: dimmer_endpoint
+      matter.dim_down: dimmer_endpoint
     on_release:
-      matter.dim_stop:
-        id: dimmer_endpoint
+      matter.dim_stop: dimmer_endpoint
 
 sensor:
   - platform: internal_temperature

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -29,6 +29,9 @@ CODEOWNERS = ["@DavidvtWout"]
 
 AUTO_LOAD = ["network"]
 
+# Only for matter-over-thread
+MIN_ESPHOME_VERSION = "2026.6.0"
+
 # Matter spec section 5.1.7.1: these passcodes are explicitly forbidden.
 _FORBIDDEN_PASSCODES = {
     11111111,
@@ -154,6 +157,9 @@ CONFIG_SCHEMA = cv.All(
 
 def _final_validate(_):
     full_config = fv.full_config.get()
+    if "openthread" in full_config:
+        cv.validate_esphome_version(MIN_ESPHOME_VERSION)
+
     network_config = full_config.get("network", {})
     if not network_config.get(CONF_ENABLE_IPV6, False):
         raise cv.Invalid(

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -277,7 +277,7 @@ async def to_code(config):
 
     # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
     add_idf_sdkconfig_option(
-        "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", thread_enabled
+        "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", False
     )  # esp-matter
     add_idf_sdkconfig_option(
         "CONFIG_ENABLE_MATTER_OVER_THREAD", thread_enabled

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -221,6 +221,20 @@ def _write_matter_cmake_hook() -> Path:
         "    if(_matter_dnssd_index EQUAL -1)\n"
         '        target_sources(${_matter_lib} PRIVATE "${_matter_dnssd}")\n'
         "    endif()\n"
+        "\n"
+        "    # With CONFIG_ESP_MATTER_ENABLE_OPENTHREAD disabled, esp-matter skips CHIP's\n"
+        "    # ThreadStackManager initialization entirely. ESPHome already created the real\n"
+        "    # OpenThread stack, so keep CHIP from initializing another one but still allow\n"
+        "    # ThreadStackMgr().InitThreadStack() to run DoInit(esp_openthread_get_instance()).\n"
+        '    set(_matter_thread_stack "${_matter_dir}/connectedhomeip/connectedhomeip/src/platform/ESP32/ThreadStackManagerImpl.cpp")\n'
+        '    file(READ "${_matter_thread_stack}" _matter_thread_stack_content)\n'
+        '    if(NOT _matter_thread_stack_content MATCHES "ESPHome owns OpenThread stack")\n'
+        "        string(REPLACE\n"
+        '            "    openthread_init_stack();"\n'
+        '            "    // ESPHome owns OpenThread stack; only bind CHIP ThreadStackManager to the existing instance."\n'
+        '            _matter_thread_stack_content "${_matter_thread_stack_content}")\n'
+        '        file(WRITE "${_matter_thread_stack}" "${_matter_thread_stack_content}")\n'
+        "    endif()\n"
         "endfunction()\n"
         "\n"
         'cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL esphome_matter_patch_esp_matter_target)\n',

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -271,12 +271,16 @@ async def to_code(config):
         )  # connectedhomeip
 
     if use_openthread:
+        # Force the Matter Thread DNS-SD bridge object into the final link. ESP-IDF/PlatformIO may compile
+        # component sources that the static-link step still discards unless an exported symbol is referenced.
+        cg.add_build_flag("-Wl,-u,esphome_matter_link_thread_dnssd")
+
         # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled. It stops
         # esp-matter from initializing an openthread stack (the openthread component already does that).
         add_idf_sdkconfig_option(
             "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", False
         )  # esp-matter
-        # add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS_CLIENT", True)
+
         add_idf_sdkconfig_option("CONFIG_ENABLE_CHIP_DATA_MODEL", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
 

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -247,11 +247,11 @@ async def to_code(config):
 
     # There is no distinction between ethernet and wifi for esp-matter since esphome already manages the
     # connection layer. So it's easier to bundle these two together.
-    lan_enabled = (
+    use_ethernet_or_wifi = (
         "ethernet" in CORE.loaded_integrations or "wifi" in CORE.loaded_integrations
     )
-    thread_enabled = "openthread" in CORE.loaded_integrations
-    connectivity_enabled = lan_enabled or thread_enabled
+    use_openthread = "openthread" in CORE.loaded_integrations
+    use_connectivity = use_ethernet_or_wifi or use_openthread
 
     # CONFIG_USE_MINIMAL_MDNS=n makes matter use the espressif/mdns component which is also used by ESPHome.
     add_idf_sdkconfig_option("CONFIG_USE_MINIMAL_MDNS", False)  # connectedhomeip
@@ -261,12 +261,7 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
     add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
 
-    # These are connectedhomeip specific flags and must both be set to False since Wi-Fi is already managed by
-    # the ESPHome wifi component and enabling chip's Wi-Fi conflicts with this.
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
-    add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
-
-    if lan_enabled:
+    if use_ethernet_or_wifi:
         # CONFIG_ENABLE_ETHERNET_TELEMETRY is just named completely wrong. Instead of what you would expect it to do,
         # it just enables CHIP_DEVICE_CONFIG_ENABLE_ETHERNET which doesn't seem to break anything important. It makes
         # connectedhomeip "think" it's connected via ethernet which prevents it from fucking with the wifi stack, while
@@ -275,20 +270,13 @@ async def to_code(config):
             "CONFIG_ENABLE_ETHERNET_TELEMETRY", True
         )  # connectedhomeip
 
-    # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled.
-    add_idf_sdkconfig_option(
-        "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", False
-    )  # esp-matter
-    add_idf_sdkconfig_option(
-        "CONFIG_ENABLE_MATTER_OVER_THREAD", thread_enabled
-    )  # connectedhomeip
-    if thread_enabled:
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_ENABLED", True)
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS_CLIENT", True)
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CLI", False)
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CONSOLE_ENABLE", False)
-        add_idf_sdkconfig_option("CONFIG_ENABLE_MATTER_OVER_THREAD", True)
+    if use_openthread:
+        # ESP_MATTER_ENABLE_OPENTHREAD is enabled by default and must explicitly be disabled. It stops
+        # esp-matter from initializing an openthread stack (the openthread component already does that).
+        add_idf_sdkconfig_option(
+            "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", False
+        )  # esp-matter
+        # add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS_CLIENT", True)
         add_idf_sdkconfig_option("CONFIG_ENABLE_CHIP_DATA_MODEL", True)
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
 
@@ -297,15 +285,29 @@ async def to_code(config):
         # add_idf_sdkconfig_option("CONFIG_DISABLE_IPV4", True)  # connectedhomeip
 
     add_idf_sdkconfig_option(
-        "CONFIG_ENABLE_CHIPOBLE", not connectivity_enabled
+        "CONFIG_ENABLE_CHIPOBLE", not use_connectivity
     )  # connectedhomeip
-    if connectivity_enabled:
+    add_idf_sdkconfig_option(
+        "CONFIG_ENABLE_MATTER_OVER_THREAD", not use_connectivity or use_openthread
+    )  # connectedhomeip
+    if use_connectivity:
         cg.add_define("MATTER_RENDEZVOUS_ON_NETWORK")  # esphome-matter
+
+        # These are connectedhomeip specific flags and must both be set to False since Wi-Fi is already managed by
+        # the ESPHome wifi component and enabling chip's Wi-Fi conflicts with this.
+        add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_AP", False)  # connectedhomeip
+        add_idf_sdkconfig_option("CONFIG_ENABLE_WIFI_STATION", False)  # connectedhomeip
     else:
         # If no network is configured, commissioning over the network isn't possible and esphome-matter must fall
         # back to BlueTooth (BLE) commissioning (the default for most matter devices). In this mode, the device can be
         # commissioned as matter-over-thread or matter-over-wifi device depending on the hardware capabilities of the
         # device. If the device supports both, it can be commissioned in either mode.
+
+        # TODO: only enable if device supports it
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_ENABLED", True)
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CLI", False)
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CONSOLE_ENABLE", False)
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
 
         # TODO: use CORE.data?
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -225,24 +225,6 @@ void MatterComponent::setup() {
     return;
   }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-  /* Set OpenThread platform config */
-  esp_openthread_platform_config_t ot_config = {
-      .radio_config = {.radio_mode = RADIO_MODE_NATIVE},
-      .host_config = {.host_connection_mode = HOST_CONNECTION_MODE_NONE},
-      .port_config = {.storage_partition_name = "nvs",
-                      .netif_queue_size = 10,
-                      .task_queue_size = 10},
-  };
-  // TODO:
-  //  esp_openthread_platform_config_t ot_config = {
-  //      .radio_config = ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG(),
-  //      .host_config = ESP_OPENTHREAD_DEFAULT_HOST_CONFIG(),
-  //      .port_config = ESP_OPENTHREAD_DEFAULT_PORT_CONFIG(),
-  //  };
-  set_openthread_platform_config(&ot_config);
-#endif
-
   /* Matter start */
   esp_err_t err = esp_matter::start(event_callback);
   if (err != ESP_OK) {

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -179,8 +179,7 @@ static void event_callback(const ChipDeviceEvent *event, intptr_t arg) {
     ESP_LOGI(TAG, "Fabric is committed");
     break;
   case chip::DeviceLayer::DeviceEventType::kDnssdRestartNeeded:
-    ESP_LOGI(TAG, "DNS-SD restart needed");
-    chip::app::DnssdServer::Instance().StartServer();
+    ESP_LOGD(TAG, "DNS-SD restart needed");
     break;
   default:
     ESP_LOGD(TAG, "Matter event: 0x%04X", event->Type);
@@ -239,6 +238,7 @@ void MatterComponent::setup() {
 }
 
 void MatterComponent::loop() {
+#ifdef USE_WIFI
   // CHIP re-advertises DNS-SD (the _matterc._udp / _matter._tcp records) only
   // on kDnssdInitialized / kDnssdRestartNeeded events. On ESP32 those are
   // posted by CHIP's WiFi connectivity manager when the station gets an IP —
@@ -255,6 +255,7 @@ void MatterComponent::loop() {
     chip::DeviceLayer::PlatformMgr().PostEventOrDie(&event);
   }
   this->network_was_connected_ = connected;
+#endif
 }
 
 void MatterComponent::factory_reset() {

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -16,7 +16,7 @@
 #include <app/server/Server.h>
 #include <crypto/CHIPCryptoPAL.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-#include <platform/ESP32/OpenthreadLauncher.h>
+#include <platform/ThreadStackManager.h>
 #endif
 #include <lib/support/Base64.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -223,6 +223,19 @@ void MatterComponent::setup() {
     this->mark_failed();
     return;
   }
+
+#ifdef USE_OPENTHREAD
+  // ESPHome owns the OpenThread task/stack. CHIP still needs its
+  // ThreadStackManager bound to that existing instance for Thread diagnostics
+  // and other Thread helpers.
+  if (chip::DeviceLayer::ThreadStackMgr().InitThreadStack() != CHIP_NO_ERROR) {
+    ESP_LOGE(
+        TAG,
+        "Failed to bind CHIP ThreadStackManager to ESPHome OpenThread stack");
+    this->mark_failed();
+    return;
+  }
+#endif
 
   /* Matter start */
   esp_err_t err = esp_matter::start(event_callback);

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -346,10 +346,11 @@ void MatterComponent::dump_config() {
       ESP_LOGCONFIG(
           TAG,
           "    [%u] CompressedFabricId: 0x%08" PRIx32 "%08" PRIx32
-          ", NodeId: 0x%08" PRIx32 "%08" PRIx32 ", VendorId: 0x%04x%s%s",
+          ", NodeId: 0x%08" PRIx32 "%08" PRIx32 " (%" PRIu64 ")"
+          ", VendorId: 0x%04x%s%s",
           fabric.GetFabricIndex(), (uint32_t)(compressed_fabric_id >> 32),
           (uint32_t)(compressed_fabric_id), (uint32_t)(node_id >> 32),
-          (uint32_t)(node_id), (uint16_t)fabric.GetVendorId(),
+          (uint32_t)(node_id), node_id, (uint16_t)fabric.GetVendorId(),
           label[0] ? ", Label: " : "", label);
     }
   }

--- a/components/matter/matter_thread_dnssd.cpp
+++ b/components/matter/matter_thread_dnssd.cpp
@@ -1,0 +1,239 @@
+#include "esphome/core/defines.h"
+#if defined(USE_MATTER) && defined(USE_OPENTHREAD)
+
+#include "esphome/components/openthread/openthread.h"
+#include "esphome/core/log.h"
+
+#include <lib/dnssd/platform/Dnssd.h>
+#include <lib/support/CodeUtils.h>
+#include <openthread/error.h>
+#include <openthread/srp_client.h>
+
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+namespace {
+
+static const char *const TAG = "matter.dnssd";
+
+const char *protocol_to_string(chip::Dnssd::DnssdServiceProtocol protocol) {
+  switch (protocol) {
+  case chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolTcp:
+    return "_tcp";
+  case chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolUdp:
+    return "_udp";
+  default:
+    return nullptr;
+  }
+}
+
+CHIP_ERROR map_ot_error(otError error) {
+  switch (error) {
+  case OT_ERROR_NONE:
+    return CHIP_NO_ERROR;
+  case OT_ERROR_INVALID_ARGS:
+    return CHIP_ERROR_INVALID_ARGUMENT;
+  case OT_ERROR_NO_BUFS:
+    return CHIP_ERROR_NO_MEMORY;
+  case OT_ERROR_INVALID_STATE:
+    return CHIP_ERROR_INCORRECT_STATE;
+  default:
+    return CHIP_ERROR_INTERNAL;
+  }
+}
+
+struct MatterSrpService {
+  std::string instance;
+  std::string type;
+  std::vector<std::string> subtype_storage;
+  std::vector<const char *> subtype_ptrs;
+  std::vector<std::string> txt_key_storage;
+  std::vector<std::vector<uint8_t>> txt_value_storage;
+  std::vector<otDnsTxtEntry> txt_entries;
+  otSrpClientService service{};
+  bool invalid{false};
+
+  bool matches(const chip::Dnssd::DnssdService *dnssd_service) const {
+    const char *protocol = protocol_to_string(dnssd_service->mProtocol);
+    if (protocol == nullptr)
+      return false;
+    return this->instance == dnssd_service->mName &&
+           this->type == std::string(dnssd_service->mType) + "." + protocol;
+  }
+};
+
+std::vector<std::unique_ptr<MatterSrpService>> matter_services;
+
+CHIP_ERROR build_srp_service(const chip::Dnssd::DnssdService *service,
+                             std::unique_ptr<MatterSrpService> &entry) {
+  const char *protocol = protocol_to_string(service->mProtocol);
+  VerifyOrReturnError(protocol != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+  entry.reset(new (std::nothrow) MatterSrpService());
+  VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
+
+  entry->instance = service->mName;
+  entry->type = std::string(service->mType) + "." + protocol;
+
+  entry->subtype_storage.reserve(service->mSubTypeSize);
+  for (size_t i = 0; i < service->mSubTypeSize; i++) {
+    entry->subtype_storage.emplace_back(service->mSubTypes[i]);
+  }
+  entry->subtype_ptrs.reserve(entry->subtype_storage.size() + 1);
+  for (const auto &subtype : entry->subtype_storage) {
+    entry->subtype_ptrs.push_back(subtype.c_str());
+  }
+  entry->subtype_ptrs.push_back(nullptr);
+
+  entry->txt_key_storage.reserve(service->mTextEntrySize);
+  entry->txt_value_storage.reserve(service->mTextEntrySize);
+  entry->txt_entries.resize(service->mTextEntrySize);
+  for (size_t i = 0; i < service->mTextEntrySize; i++) {
+    VerifyOrReturnError(service->mTextEntries != nullptr,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    const auto &txt = service->mTextEntries[i];
+    VerifyOrReturnError(txt.mKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    entry->txt_key_storage.emplace_back(txt.mKey);
+    entry->txt_value_storage.emplace_back();
+    if (txt.mDataSize > 0) {
+      VerifyOrReturnError(txt.mData != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+      entry->txt_value_storage.back().assign(txt.mData,
+                                             txt.mData + txt.mDataSize);
+    }
+  }
+  for (size_t i = 0; i < service->mTextEntrySize; i++) {
+    entry->txt_entries[i].mKey = entry->txt_key_storage[i].c_str();
+    entry->txt_entries[i].mValue = entry->txt_value_storage[i].empty()
+                                       ? nullptr
+                                       : entry->txt_value_storage[i].data();
+    entry->txt_entries[i].mValueLength = entry->txt_value_storage[i].size();
+  }
+
+  entry->service.mName = entry->type.c_str();
+  entry->service.mInstanceName = entry->instance.c_str();
+  entry->service.mSubTypeLabels = entry->subtype_ptrs.data();
+  entry->service.mTxtEntries =
+      entry->txt_entries.empty() ? nullptr : entry->txt_entries.data();
+  entry->service.mNumTxtEntries = entry->txt_entries.size();
+  entry->service.mPort = service->mPort;
+  return CHIP_NO_ERROR;
+}
+
+} // namespace
+
+// connectedhomeip/src/platform/ESP32/DnssdImpl.cpp
+extern "C" void esphome_matter_link_thread_dnssd() {}
+
+namespace chip {
+namespace Dnssd {
+
+CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback init_callback,
+                         DnssdAsyncReturnCallback, void *context) {
+  ESP_LOGI(TAG, "Thread DNS-SD bridge linked");
+  if (init_callback != nullptr) {
+    init_callback(context, CHIP_NO_ERROR);
+  }
+  return CHIP_NO_ERROR;
+}
+
+void ChipDnssdShutdown() { ESP_LOGD(TAG, "ChipDnssdShutdown"); }
+
+CHIP_ERROR ChipDnssdPublishService(const DnssdService *service,
+                                   DnssdPublishCallback callback,
+                                   void *context) {
+  VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+  std::unique_ptr<MatterSrpService> entry;
+  ReturnErrorOnFailure(build_srp_service(service, entry));
+
+  auto lock = esphome::openthread::InstanceLock::try_acquire(2000);
+  VerifyOrReturnError(static_cast<bool>(lock), CHIP_ERROR_INCORRECT_STATE);
+
+  otInstance *instance = lock.get_instance();
+  for (auto it = matter_services.begin(); it != matter_services.end();) {
+    if ((*it)->matches(service)) {
+      otSrpClientClearService(instance, &(*it)->service);
+      it = matter_services.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  otError error = otSrpClientAddService(instance, &entry->service);
+  CHIP_ERROR chip_error = map_ot_error(error);
+  if (chip_error == CHIP_NO_ERROR) {
+    ESP_LOGD(TAG, "Publishing %s.%s via ESPHome OpenThread SRP", service->mName,
+             entry->type.c_str());
+    matter_services.push_back(std::move(entry));
+  } else {
+    ESP_LOGW(TAG, "Failed to publish %s.%s via ESPHome OpenThread SRP: %d",
+             service->mName, entry->type.c_str(), error);
+  }
+
+  if (callback != nullptr) {
+    callback(context, chip_error == CHIP_NO_ERROR ? service->mType : nullptr,
+             chip_error == CHIP_NO_ERROR ? service->mName : nullptr,
+             chip_error);
+  }
+  return chip_error;
+}
+
+CHIP_ERROR ChipDnssdRemoveServices() {
+  auto lock = esphome::openthread::InstanceLock::try_acquire(2000);
+  VerifyOrReturnError(static_cast<bool>(lock), CHIP_ERROR_INCORRECT_STATE);
+
+  for (auto &entry : matter_services) {
+    ESP_LOGD(TAG, "Marking SRP service for removal: %s.%s",
+             entry->instance.c_str(), entry->type.c_str());
+    entry->invalid = true;
+  }
+  return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDnssdFinalizeServiceUpdate() {
+  auto lock = esphome::openthread::InstanceLock::try_acquire(2000);
+  VerifyOrReturnError(static_cast<bool>(lock), CHIP_ERROR_INCORRECT_STATE);
+
+  otInstance *instance = lock.get_instance();
+  for (auto it = matter_services.begin(); it != matter_services.end();) {
+    if ((*it)->invalid) {
+      ESP_LOGD(TAG, "Removing stale %s.%s from ESPHome OpenThread SRP",
+               (*it)->instance.c_str(), (*it)->type.c_str());
+      otSrpClientClearService(instance, &(*it)->service);
+      it = matter_services.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDnssdBrowse(const char *, DnssdServiceProtocol,
+                           chip::Inet::IPAddressType, chip::Inet::InterfaceId,
+                           DnssdBrowseCallback, void *, intptr_t *) {
+  ESP_LOGW(TAG, "ChipDnssdBrowse not yet implemented!");
+  return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipDnssdStopBrowse(intptr_t) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+CHIP_ERROR ChipDnssdResolve(DnssdService *, chip::Inet::InterfaceId,
+                            DnssdResolveCallback, void *) {
+  ESP_LOGW(TAG, "ChipDnssdResolve not yet implemented!");
+  return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+void ChipDnssdResolveNoLongerNeeded(const char *) {}
+
+CHIP_ERROR ChipDnssdReconfirmRecord(const char *, chip::Inet::IPAddress,
+                                    chip::Inet::InterfaceId) {
+  return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+} // namespace Dnssd
+} // namespace chip
+
+#endif // USE_MATTER && USE_OPENTHREAD

--- a/docs/dev/thread-debugging.md
+++ b/docs/dev/thread-debugging.md
@@ -1,0 +1,45 @@
+### OpenThread BorderRouter (OTBR)
+
+If you run OTBR you have access to the following commands.
+
+`ot-ctl srp server host` can be used to find the IPv6 address of the esphome device;
+
+```
+# ot-ctl srp server host
+<esphome-device-name>.default.service.arpa.
+    deleted: false
+    addresses: [fd87:...]
+    lease: 7200
+    key-lease: 680400
+    remaining lease: 6848.955
+    remaining key-lease: 682048.955
+```
+
+`ot-ctl srp server service` finds the services and the output should look like this for a commissioned device;
+
+```
+# ot-ctl srp server service
+<fabrid-id>-<node-id>._matter._tcp.default.service.arpa.
+    subtypes: _I<fabrid-id>
+    port: 5540
+    TXT: [...]
+    host: <esphome-device-name>.default.service.arpa.
+    addresses: [fd87:...]
+    ...
+<esphome-device-name>._esphomelib._tcp.default.service.arpa.
+    port: 6053
+    ...
+```
+
+And like this for an uncommissioned device;
+
+```
+# ot-ctl srp server service
+<esphome-device-name>._esphomelib._tcp.default.service.arpa.
+    port: 6053
+    ...
+<something>._matterc._udp.default.service.arpa.
+    ...
+```
+
+Sadly, `ot-ctl` is pure trash and shows deleted records for a whole week and doesn't allow you to filter on anything. So I would recomment to enable [SRP Advertising Proxy](https://deepwiki.com/openthread/ot-br-posix/6.3-srp-advertising-proxy) in OTBR (I think this is done for most builds anyway?). This proxies the SRP services to the backbone interface via mdns. These can then be discovered with `mdns-scanner`, `avahi-browse` or other mdns discovery tools.


### PR DESCRIPTION
Matter-over-hread is now working! I added overrides for CHIP’s platform DNS-SD functions so Matter advertisements are published through the SRP client already managed by ESPHome’s openthread component.

Service advertisement and commissioning are fully functional now. 
Service discovery isn't working, so binding isn't either.

Tested on an `ESP32-C6` and `ESP32-H2`. If this PR doesn't break matter-over-wifi I'll merge later today.

Update: It does break matter-over-wifi so I won't merge this PR now. If you want to test matter-over-thread, point your device config to this branch:

```yaml
external_components:
  - source: github://DavidvtWout/esphome-matter@matter-over-thread
```