### PR TITLE
Support binding

### DIFF
--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -214,6 +214,18 @@ def _write_matter_cmake_hook() -> Path:
         '            _matter_thread_stack_content "${_matter_thread_stack_content}")\n'
         '        file(WRITE "${_matter_thread_stack}" "${_matter_thread_stack_content}")\n'
         "    endif()\n"
+        "\n"
+        "    # Our Thread DNS-SD bridge owns ChipDnssdPublishService() so Matter advertises via\n"
+        "    # ESPHome's existing OpenThread SRP client, but CHIP's OpenThread helper already\n"
+        "    # implements DNS browse/resolve through ThreadStackMgr(). Pull in that helper so\n"
+        "    # operational CASE discovery can resolve peers after commissioning.\n"
+        '    set(_matter_openthread_dnssd "${_matter_dir}/connectedhomeip/connectedhomeip/src/platform/OpenThread/OpenThreadDnssdImpl.cpp")\n'
+        "    get_target_property(_matter_sources ${_matter_lib} SOURCES)\n"
+        '    list(FIND _matter_sources "${_matter_openthread_dnssd}" _matter_openthread_dnssd_index)\n'
+        "    if(CONFIG_ENABLE_MATTER_OVER_THREAD AND _matter_openthread_dnssd_index EQUAL -1)\n"
+        '        target_sources(${_matter_lib} PRIVATE "${_matter_openthread_dnssd}")\n'
+        "    endif()\n"
+        "\n"
         "endfunction()\n"
         "\n"
         'cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL esphome_matter_patch_esp_matter_target)\n',
@@ -279,6 +291,10 @@ async def to_code(config):
             "CONFIG_ESP_MATTER_ENABLE_OPENTHREAD", False
         )  # esp-matter
 
+        # Force the Matter Thread DNS-SD bridge object into the final link. ESP-IDF/PlatformIO may compile
+        # component sources that the static-link step still discards unless an exported symbol is referenced.
+        cg.add_build_flag("-Wl,-u,esphome_matter_link_thread_dnssd")
+        # add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS_CLIENT", True)
         add_idf_sdkconfig_option("CONFIG_ENABLE_CHIP_DATA_MODEL", True)  # esp-matter
         add_idf_sdkconfig_option("CONFIG_LWIP_MULTICAST_PING", True)
 

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -266,8 +266,6 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_ENABLE_EXTENDED_DISCOVERY", True)
 
     add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_NUM_ADDRESSES", 6)
-    add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT", True)
-    add_idf_sdkconfig_option("CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT", True)
 
     # Disable Intermittently Connected Device (ICD).
     add_idf_sdkconfig_option("CONFIG_ENABLE_ICD_SERVER", False)  # connectedhomeip

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -314,8 +314,9 @@ async def to_code(config):
         cg.add_build_flag(
             "-Wl,--wrap=_ZN4chip11DeviceLayer8Internal10ESP32Utils13InitWiFiStackEv"
         )
+        cg.add_build_flag("-Wl,-u,esphome_matter_link_wifi_dnssd")
     if use_wifi or use_ethernet:
-        # lwIP must add the route to thread network via the border router to its routing table.
+        # lwIP must add the route to the thread network via the border router to its routing table.
         add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_ND6_ROUTE_INFO_OPTION_SUPPORT", True)
 
     add_idf_sdkconfig_option(

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -314,6 +314,9 @@ async def to_code(config):
         cg.add_build_flag(
             "-Wl,--wrap=_ZN4chip11DeviceLayer8Internal10ESP32Utils13InitWiFiStackEv"
         )
+    if use_wifi or use_ethernet:
+        # lwIP must add the route to thread network via the border router to its routing table.
+        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_ND6_ROUTE_INFO_OPTION_SUPPORT", True)
 
     add_idf_sdkconfig_option(
         "CONFIG_ENABLE_CHIPOBLE", not use_connectivity

--- a/components/matter/matter_actions.cpp
+++ b/components/matter/matter_actions.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <inttypes.h>
+#include <string>
 
 static const char *const TAG = "matter.actions";
 
@@ -71,23 +72,21 @@ void register_client_request_callbacks() {
 void send_client_command(uint16_t endpoint_id, chip::ClusterId cluster,
                          chip::CommandId command, uint8_t move_mode) {
   auto &binding_table = chip::app::Clusters::Binding::Table::GetInstance();
-  char node_ids[128] = {};
-  size_t pos = 0;
+  std::string node_ids;
   for (const auto &entry : binding_table) {
     if (entry.local == endpoint_id &&
         (!entry.clusterId.has_value() || entry.clusterId.value() == cluster)) {
-      pos +=
-          snprintf(node_ids + pos, sizeof(node_ids) - pos,
-                   pos == 0 ? "0x%016" PRIx64 : " 0x%016" PRIx64, entry.nodeId);
-      if (pos >= sizeof(node_ids))
-        break;
+      if (!node_ids.empty())
+        node_ids += ",";
+      char node_id[21];
+      snprintf(node_id, sizeof(node_id), "%" PRIu64,
+               static_cast<uint64_t>(entry.nodeId));
+      node_ids += node_id;
     }
   }
-  ESP_LOGD(TAG,
-           "Sending command nodes=[%s] endpoint=%u cluster=0x%08" PRIx32
-           " command=0x%08" PRIx32 " bindings=%u",
-           node_ids, endpoint_id, static_cast<uint32_t>(cluster),
-           static_cast<uint32_t>(command), binding_table.Size());
+  ESP_LOGD(TAG, "Sending command nodes=[%s] endpoint=%u cluster=%u command=%u",
+           node_ids.empty() ? "none" : node_ids.c_str(), endpoint_id,
+           static_cast<uint32_t>(cluster), static_cast<uint32_t>(command));
 
   esp_matter::client::request_handle_t req;
   req.type = esp_matter::client::INVOKE_CMD;
@@ -96,7 +95,10 @@ void send_client_command(uint16_t endpoint_id, chip::ClusterId cluster,
   req.request_data =
       reinterpret_cast<void *>(static_cast<uintptr_t>(move_mode));
   esp_matter::lock::ScopedChipStackLock scoped_lock(portMAX_DELAY);
-  esp_matter::client::cluster_update(endpoint_id, &req);
+  esp_err_t err = esp_matter::client::cluster_update(endpoint_id, &req);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "cluster_update failed: %s", esp_err_to_name(err));
+  }
 }
 
 } // namespace esphome::matter

--- a/components/matter/matter_actions.cpp
+++ b/components/matter/matter_actions.cpp
@@ -15,13 +15,32 @@ static const char *const TAG = "matter.actions";
 
 namespace esphome::matter {
 
+static void invoke_response_cb(void *,
+                               const chip::app::ConcreteCommandPath &path,
+                               const chip::app::StatusIB &status,
+                               chip::TLV::TLVReader *) {
+  ESP_LOGD(TAG,
+           "Invoke response endpoint=%u cluster=%lu command=%lu status=0x%02x",
+           static_cast<unsigned>(path.mEndpointId),
+           static_cast<unsigned long>(path.mClusterId),
+           static_cast<unsigned long>(path.mCommandId),
+           static_cast<unsigned>(status.mStatus));
+}
+
+static void invoke_failure_cb(void *, CHIP_ERROR error) {
+  ESP_LOGE(TAG, "Invoke failed: %" CHIP_ERROR_FORMAT, error.Format());
+}
+
 // Builds the JSON command payload for outgoing client commands. Called by
 // esp_matter for every command sent through cluster_update().
 static void client_invoke_cb(esp_matter::client::peer_device_t *peer_device,
                              esp_matter::client::request_handle_t *req_handle,
                              void *priv_data) {
-  if (req_handle->type != esp_matter::client::INVOKE_CMD)
+  if (req_handle->type != esp_matter::client::INVOKE_CMD) {
+    ESP_LOGV(TAG, "skipping client_invoke_cb");
     return;
+  }
+  ESP_LOGV(TAG, "client_invoke_cb");
   using namespace chip::app::Clusters;
   char cmd_data[48] = "{}";
   if (req_handle->command_path.mClusterId == LevelControl::Id) {
@@ -36,17 +55,21 @@ static void client_invoke_cb(esp_matter::client::peer_device_t *peer_device,
       strcpy(cmd_data, "{\"0:U8\": 0, \"1:U8\": 0}");
     }
   }
+  ESP_LOGV(TAG, "client_invoke_cb: %s", cmd_data);
   esp_matter::client::interaction::invoke::send_request(
-      nullptr, peer_device, req_handle->command_path, cmd_data, nullptr,
-      nullptr, chip::NullOptional);
+      nullptr, peer_device, req_handle->command_path, cmd_data,
+      invoke_response_cb, invoke_failure_cb, chip::NullOptional);
 }
 
 static void
 client_group_invoke_cb(uint8_t fabric_index,
                        esp_matter::client::request_handle_t *req_handle,
                        void *priv_data) {
-  if (req_handle->type != esp_matter::client::INVOKE_CMD)
+  if (req_handle->type != esp_matter::client::INVOKE_CMD) {
+    ESP_LOGV(TAG, "skipping client_group_invoke_cb");
     return;
+  }
+  ESP_LOGV(TAG, "client_group_invoke_cb");
   using namespace chip::app::Clusters;
   char cmd_data[48] = "{}";
   if (req_handle->command_path.mClusterId == LevelControl::Id) {
@@ -60,6 +83,7 @@ client_group_invoke_cb(uint8_t fabric_index,
       strcpy(cmd_data, "{\"0:U8\": 0, \"1:U8\": 0}");
     }
   }
+  ESP_LOGV(TAG, "client_group_invoke_cb: %s", cmd_data);
   esp_matter::client::interaction::invoke::send_group_request(
       fabric_index, req_handle->command_path, cmd_data);
 }

--- a/components/matter/matter_actions.cpp
+++ b/components/matter/matter_actions.cpp
@@ -3,8 +3,14 @@
 
 #include "matter_actions.h"
 
+#include "esphome/core/log.h"
+
+#include <app/clusters/bindings/binding-table.h>
 #include <cstdio>
 #include <cstring>
+#include <inttypes.h>
+
+static const char *const TAG = "matter.actions";
 
 namespace esphome::matter {
 
@@ -64,6 +70,25 @@ void register_client_request_callbacks() {
 
 void send_client_command(uint16_t endpoint_id, chip::ClusterId cluster,
                          chip::CommandId command, uint8_t move_mode) {
+  auto &binding_table = chip::app::Clusters::Binding::Table::GetInstance();
+  char node_ids[128] = {};
+  size_t pos = 0;
+  for (const auto &entry : binding_table) {
+    if (entry.local == endpoint_id &&
+        (!entry.clusterId.has_value() || entry.clusterId.value() == cluster)) {
+      pos +=
+          snprintf(node_ids + pos, sizeof(node_ids) - pos,
+                   pos == 0 ? "0x%016" PRIx64 : " 0x%016" PRIx64, entry.nodeId);
+      if (pos >= sizeof(node_ids))
+        break;
+    }
+  }
+  ESP_LOGD(TAG,
+           "Sending command nodes=[%s] endpoint=%u cluster=0x%08" PRIx32
+           " command=0x%08" PRIx32 " bindings=%u",
+           node_ids, endpoint_id, static_cast<uint32_t>(cluster),
+           static_cast<uint32_t>(command), binding_table.Size());
+
   esp_matter::client::request_handle_t req;
   req.type = esp_matter::client::INVOKE_CMD;
   req.command_path.mClusterId = cluster;

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstring>
+#include <esp_matter_client.h>
 #include <esp_random.h>
 #include <nvs.h>
 #include <string>
@@ -253,6 +254,7 @@ void MatterComponent::setup() {
     ESP_LOGD(TAG, "Matter started successfully");
   }
 
+  esp_matter::client::binding_manager_init();
   this->register_endpoint_callbacks_();
 }
 

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -210,6 +210,9 @@ static void event_callback(const ChipDeviceEvent *event, intptr_t arg) {
   case chip::DeviceLayer::DeviceEventType::kThreadStateChange: // 0x800B
     ESP_LOGV(TAG_EVENT, "ThreadStateChange");
     break;
+  case chip::DeviceLayer::DeviceEventType::kDnssdInitialized: // 0x8012
+    ESP_LOGV(TAG_EVENT, "DnssdInitialized");
+    break;
   default:
     ESP_LOGV(TAG_EVENT, "0x%04X", event->Type);
     break;

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -25,6 +25,7 @@
 #include <setup_payload/SetupPayload.h>
 
 static const char *const TAG = "matter";
+static const char *const TAG_EVENT = "matter.event";
 
 // Keys in the "chip-factory" NVS namespace, matching CHIP's ESP32Config key
 // names.
@@ -146,53 +147,71 @@ MatterComponent *global_matter_component =
 static void event_callback(const ChipDeviceEvent *event, intptr_t arg) {
   switch (event->Type) {
   case chip::DeviceLayer::DeviceEventType::kInterfaceIpAddressChanged:
-    ESP_LOGD(TAG, "Interface IP Address changed");
+    ESP_LOGD(TAG_EVENT, "Interface IP Address changed");
     break;
   case chip::DeviceLayer::DeviceEventType::kCommissioningComplete:
-    ESP_LOGI(TAG, "Commissioning complete");
+    ESP_LOGI(TAG_EVENT, "Commissioning complete");
     break;
   case chip::DeviceLayer::DeviceEventType::kFailSafeTimerExpired:
-    ESP_LOGI(TAG, "Commissioning failed, fail safe timer expired");
+    ESP_LOGI(TAG_EVENT, "Commissioning failed, fail safe timer expired");
     break;
   case chip::DeviceLayer::DeviceEventType::kCommissioningSessionStarted:
-    ESP_LOGI(TAG, "Commissioning session started");
+    ESP_LOGI(TAG_EVENT, "Commissioning session started");
     break;
   case chip::DeviceLayer::DeviceEventType::kCommissioningSessionStopped:
-    ESP_LOGI(TAG, "Commissioning session stopped");
+    ESP_LOGI(TAG_EVENT, "Commissioning session stopped");
     break;
   case chip::DeviceLayer::DeviceEventType::kCommissioningWindowOpened:
-    ESP_LOGI(TAG, "Commissioning window opened");
+    ESP_LOGI(TAG_EVENT, "Commissioning window opened");
     break;
   case chip::DeviceLayer::DeviceEventType::kCommissioningWindowClosed:
-    ESP_LOGI(TAG, "Commissioning window closed");
+    ESP_LOGI(TAG_EVENT, "Commissioning window closed");
     break;
   case chip::DeviceLayer::DeviceEventType::kFabricRemoved:
-    ESP_LOGI(TAG, "Fabric removed");
+    ESP_LOGI(TAG_EVENT, "Fabric removed");
     // TODO: reopen commissioning window?
     break;
   case chip::DeviceLayer::DeviceEventType::kFabricWillBeRemoved:
-    ESP_LOGI(TAG, "Fabric will be removed");
+    ESP_LOGI(TAG_EVENT, "Fabric will be removed");
     break;
   case chip::DeviceLayer::DeviceEventType::kFabricUpdated:
-    ESP_LOGI(TAG, "Fabric is updated");
+    ESP_LOGI(TAG_EVENT, "Fabric is updated");
     break;
   case chip::DeviceLayer::DeviceEventType::kFabricCommitted:
-    ESP_LOGI(TAG, "Fabric is committed");
+    ESP_LOGI(TAG_EVENT, "Fabric is committed");
     break;
   case chip::DeviceLayer::DeviceEventType::kDnssdRestartNeeded:
-    ESP_LOGD(TAG, "DNS-SD restart needed");
+    ESP_LOGD(TAG_EVENT, "DNS-SD restart needed");
     break;
   case chip::DeviceLayer::DeviceEventType::kBindingsChangedViaCluster:
-    ESP_LOGI(TAG, "Bindings updated");
+    ESP_LOGI(TAG_EVENT, "Bindings updated");
     break;
   case chip::DeviceLayer::DeviceEventType::kServerReady:
-    ESP_LOGI(TAG, "Server ready!");
+    ESP_LOGI(TAG_EVENT, "Server ready!");
     break;
-  case chip::DeviceLayer::DeviceEventType::kThreadStateChange:
-    ESP_LOGV(TAG, "event: ThreadStateChange");
+  case chip::DeviceLayer::DeviceEventType::kSecureSessionEstablished: {
+    const auto &s = event->SecureSessionEstablished;
+    ESP_LOGI(TAG_EVENT,
+             "Secure session established: %s node=0x%016" PRIx64
+             " fabric=%u session=%u",
+             s.SecureSessionType == 2   ? "CASE"
+             : s.SecureSessionType == 1 ? "PASE"
+                                        : "?",
+             s.PeerNodeId, s.FabricIndex, s.LocalSessionId);
+    break;
+  }
+  case chip::DeviceLayer::DeviceEventType::kWiFiConnectivityChange: // 0x8000
+    ESP_LOGV(TAG_EVENT, "WiFiConnectivityChange");
+    break;
+  case chip::DeviceLayer::DeviceEventType::
+      kInternetConnectivityChange: // 0x8002
+    ESP_LOGV(TAG_EVENT, "InternetConnectivityChange");
+    break;
+  case chip::DeviceLayer::DeviceEventType::kThreadStateChange: // 0x800B
+    ESP_LOGV(TAG_EVENT, "ThreadStateChange");
     break;
   default:
-    ESP_LOGV(TAG, "event: 0x%04X", event->Type);
+    ESP_LOGV(TAG_EVENT, "0x%04X", event->Type);
     break;
   }
 }

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -261,8 +261,6 @@ void MatterComponent::setup() {
   this->register_endpoint_callbacks_();
 }
 
-void MatterComponent::loop() {}
-
 void MatterComponent::factory_reset() {
   ESP_LOGW(TAG, "Matter factory reset. Erasing fabric data and rebooting");
   for (const char *ns : {"chip-config", "chip-counters", "CHIP_KVS"}) {

--- a/components/matter/matter_component.cpp
+++ b/components/matter/matter_component.cpp
@@ -188,8 +188,11 @@ static void event_callback(const ChipDeviceEvent *event, intptr_t arg) {
   case chip::DeviceLayer::DeviceEventType::kServerReady:
     ESP_LOGI(TAG, "Server ready!");
     break;
+  case chip::DeviceLayer::DeviceEventType::kThreadStateChange:
+    ESP_LOGV(TAG, "event: ThreadStateChange");
+    break;
   default:
-    ESP_LOGV(TAG, "Matter event: 0x%04X", event->Type);
+    ESP_LOGV(TAG, "event: 0x%04X", event->Type);
     break;
   }
 }

--- a/components/matter/matter_component.h
+++ b/components/matter/matter_component.h
@@ -16,7 +16,6 @@ namespace esphome::matter {
 class MatterComponent : public Component {
 public:
   void setup() override;
-  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override {
 #ifdef USE_OPENTHREAD

--- a/components/matter/matter_endpoints.cpp
+++ b/components/matter/matter_endpoints.cpp
@@ -79,9 +79,7 @@ bool MatterComponent::create_endpoints_(esp_matter::node_t *node) {
   }
 #endif
 
-  if (!this->on_off_switches_.empty() || !this->dimmer_switches_.empty()) {
-    register_client_request_callbacks();
-  }
+  register_client_request_callbacks();
 
   return true;
 }

--- a/components/matter/matter_thread_dnssd.cpp
+++ b/components/matter/matter_thread_dnssd.cpp
@@ -8,6 +8,7 @@
 #include <lib/support/CodeUtils.h>
 #include <openthread/error.h>
 #include <openthread/srp_client.h>
+#include <platform/OpenThread/OpenThreadDnssdImpl.h>
 
 #include <memory>
 #include <new>
@@ -211,19 +212,25 @@ CHIP_ERROR ChipDnssdFinalizeServiceUpdate() {
   return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDnssdBrowse(const char *, DnssdServiceProtocol,
-                           chip::Inet::IPAddressType, chip::Inet::InterfaceId,
-                           DnssdBrowseCallback, void *, intptr_t *) {
-  ESP_LOGW(TAG, "ChipDnssdBrowse not yet implemented!");
-  return CHIP_ERROR_NOT_IMPLEMENTED;
+CHIP_ERROR ChipDnssdBrowse(const char *type, DnssdServiceProtocol protocol,
+                           chip::Inet::IPAddressType address_type,
+                           chip::Inet::InterfaceId interface,
+                           DnssdBrowseCallback callback, void *context,
+                           intptr_t *browse_identifier) {
+  ESP_LOGD(TAG, "Delegating Thread DNS-SD browse for %s",
+           type != nullptr ? type : "(null)");
+  return OpenThreadDnssdBrowse(type, protocol, address_type, interface,
+                               callback, context, browse_identifier);
 }
 
 CHIP_ERROR ChipDnssdStopBrowse(intptr_t) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-CHIP_ERROR ChipDnssdResolve(DnssdService *, chip::Inet::InterfaceId,
-                            DnssdResolveCallback, void *) {
-  ESP_LOGW(TAG, "ChipDnssdResolve not yet implemented!");
-  return CHIP_ERROR_NOT_IMPLEMENTED;
+CHIP_ERROR ChipDnssdResolve(DnssdService *browse_result,
+                            chip::Inet::InterfaceId interface,
+                            DnssdResolveCallback callback, void *context) {
+  ESP_LOGD(TAG, "Delegating Thread DNS-SD resolve for %s",
+           browse_result != nullptr ? browse_result->mName : "(null)");
+  return OpenThreadDnssdResolve(browse_result, interface, callback, context);
 }
 
 void ChipDnssdResolveNoLongerNeeded(const char *) {}

--- a/components/matter/matter_wifi_dnssd.cpp
+++ b/components/matter/matter_wifi_dnssd.cpp
@@ -1,0 +1,156 @@
+#include "esphome/core/defines.h"
+#if defined(USE_MATTER) && defined(USE_WIFI)
+
+#include "esphome/core/log.h"
+
+#include <inet/IPAddress.h>
+#include <lib/dnssd/platform/Dnssd.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/ESP32/ESP32DnssdImpl.h>
+#include <platform/ESP32/ESP32Utils.h>
+
+#include <new>
+
+namespace {
+
+static const char *const TAG = "matter.dnssd";
+
+const char *protocol_to_string(chip::Dnssd::DnssdServiceProtocol protocol) {
+  switch (protocol) {
+  case chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolTcp:
+    return "_tcp";
+  case chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolUdp:
+    return "_udp";
+  default:
+    return "?";
+  }
+}
+
+struct WifiResolveContext {
+  chip::Dnssd::DnssdResolveCallback callback;
+  void *context;
+};
+
+void resolve_callback(void *context, chip::Dnssd::DnssdService *service,
+                      const chip::Span<chip::Inet::IPAddress> &addresses,
+                      CHIP_ERROR error) {
+  auto *resolve_context = static_cast<WifiResolveContext *>(context);
+
+  if (service != nullptr) {
+    ESP_LOGD(TAG, "resolved %s.%s.%s as %s:%u", service->mName, service->mType,
+             protocol_to_string(service->mProtocol), service->mHostName,
+             service->mPort);
+  } else {
+    ESP_LOGW(TAG, "resolved service=(null)");
+  }
+  for (const auto &address : addresses) {
+    char address_string[chip::Inet::IPAddress::kMaxStringLength];
+    address.ToString(address_string);
+    ESP_LOGV(TAG, "%s address: %s", service->mHostName, address_string);
+  }
+
+  if (resolve_context->callback != nullptr) {
+    resolve_context->callback(resolve_context->context, service, addresses,
+                              error);
+  }
+  chip::Platform::Delete(resolve_context);
+}
+
+} // namespace
+
+// connectedhomeip/src/platform/ESP32/DnssdImpl.cpp
+extern "C" void esphome_matter_link_wifi_dnssd() {}
+
+namespace chip {
+namespace Dnssd {
+
+CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback init_callback,
+                         DnssdAsyncReturnCallback error_callback,
+                         void *context) {
+  ESP_LOGI(TAG, "Wi-Fi DNS-SD bridge linked");
+  return EspDnssdInit(init_callback, error_callback, context);
+}
+
+void ChipDnssdShutdown() { ESP_LOGD(TAG, "ChipDnssdShutdown"); }
+
+CHIP_ERROR ChipDnssdPublishService(const DnssdService *service,
+                                   DnssdPublishCallback callback,
+                                   void *context) {
+  if (service == nullptr) {
+    ESP_LOGW(TAG, "Can't publish because DnssdService isn't initialized");
+  } else {
+    ESP_LOGD(TAG, "publishing %s.%s.%s as %s:%u", service->mName,
+             service->mType, protocol_to_string(service->mProtocol),
+             service->mHostName, service->mPort);
+  }
+
+  return EspDnssdPublishService(service, callback, context);
+}
+
+CHIP_ERROR ChipDnssdRemoveServices() {
+  ESP_LOGD(TAG, "remove services");
+  return EspDnssdRemoveServices();
+}
+
+CHIP_ERROR ChipDnssdFinalizeServiceUpdate() {
+  ESP_LOGD(TAG, "finalize service update");
+  return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDnssdBrowse(const char *type, DnssdServiceProtocol protocol,
+                           chip::Inet::IPAddressType address_type,
+                           chip::Inet::InterfaceId interface,
+                           DnssdBrowseCallback callback, void *context,
+                           intptr_t *browse_identifier) {
+  ESP_LOGD(TAG, "browse type=%s protocol=%s", type != nullptr ? type : "(null)",
+           protocol_to_string(protocol));
+  return EspDnssdBrowse(type, protocol, address_type, interface, callback,
+                        context, browse_identifier);
+}
+
+CHIP_ERROR ChipDnssdStopBrowse(intptr_t) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+CHIP_ERROR ChipDnssdResolve(DnssdService *service,
+                            chip::Inet::InterfaceId interface,
+                            DnssdResolveCallback callback, void *context) {
+
+  if (service == nullptr) {
+    ESP_LOGW(TAG, "Can't resolve because DnssdService isn't initialized");
+  } else {
+    ESP_LOGD(TAG, "resolving %s.%s.%s", service->mName, service->mType,
+             protocol_to_string(service->mProtocol));
+  }
+
+  auto *resolve_context = chip::Platform::New<WifiResolveContext>();
+  VerifyOrReturnError(resolve_context != nullptr, CHIP_ERROR_NO_MEMORY);
+  resolve_context->callback = callback;
+  resolve_context->context = context;
+
+  CHIP_ERROR error =
+      EspDnssdResolve(service, interface, resolve_callback, resolve_context);
+  if (error != CHIP_NO_ERROR) {
+    ESP_LOGW(TAG, "Wi-Fi DNS-SD resolve start failed: %" CHIP_ERROR_FORMAT,
+             error.Format());
+    chip::Platform::Delete(resolve_context);
+  }
+  return error;
+}
+
+void ChipDnssdResolveNoLongerNeeded(const char *instance_name) {
+  ESP_LOGV(TAG, "resolve no longer needed for %s",
+           instance_name != nullptr ? instance_name : "(null)");
+}
+
+CHIP_ERROR ChipDnssdReconfirmRecord(const char *hostname, chip::Inet::IPAddress,
+                                    chip::Inet::InterfaceId) {
+  ESP_LOGD(TAG, "reconfirm hostname=%s",
+           hostname != nullptr ? hostname : "(null)");
+  return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+} // namespace Dnssd
+} // namespace chip
+
+#endif // USE_MATTER && USE_WIFI

--- a/examples/esp32-ble-commissioning.yaml
+++ b/examples/esp32-ble-commissioning.yaml
@@ -14,16 +14,16 @@
 #   A: I haven't implemented support for that so don't know... Just don't do that?
 
 esphome:
-  name: matter-device
-  friendly_name: Matter Device
+  name: matter-ble-commissioning
 
 esp32:
+  toolchain: platformio
+  variant: # Set to your variant
   framework:
     type: esp-idf
 
 external_components:
   - source: github://DavidvtWout/esphome-matter@main
-    refresh: 0s
 
 logger:
 

--- a/examples/esp32-dimmer-button.yaml
+++ b/examples/esp32-dimmer-button.yaml
@@ -1,18 +1,22 @@
 # This example involved a pre-configured openthread network. This way, the api is immediately available, even before
 # matter is commissioned.
+# After commissioning, the binding cluster (0x1e or 31) of the dimmer switch endpoint needs to be configured to point
+# to the node id and cluster id of a matter light. The frontend of the python-matter-server has "Binding" button
+# when you go to the binding cluster. This also adds the node id of the esphome device to the ACL of the light
+# to make it accept the commands that the esphome device will send after binding.
 
 esphome:
   name: matter-device
   friendly_name: Matter Device
 
 esp32:
+  toolchain: platformio
+  variant: # Set to your variant
   framework:
-    variant: ESP32C6
     type: esp-idf
 
 external_components:
   - source: github://DavidvtWout/esphome-matter@main
-    refresh: 0s
 
 logger:
 
@@ -40,14 +44,11 @@ binary_sensor:
         input: true
       inverted: true
     on_click:
-      matter.turn_on:
-        id: dimmer_endpoint
+      matter.turn_on: dimmer_endpoint
     on_press:
-      matter.dim_up:
-        id: dimmer_endpoint
+      matter.dim_up: dimmer_endpoint
     on_release:
-      matter.dim_stop:
-        id: dimmer_endpoint
+      matter.dim_stop: dimmer_endpoint
   - name: "Button down"
     id: button_down
     platform: gpio
@@ -58,11 +59,8 @@ binary_sensor:
         input: true
       inverted: true
     on_click:
-      matter.turn_off:
-        id: dimmer_endpoint
+      matter.turn_off: dimmer_endpoint
     on_press:
-      matter.dim_down:
-        id: dimmer_endpoint
+      matter.dim_down: dimmer_endpoint
     on_release:
-      matter.dim_stop:
-        id: dimmer_endpoint
+      matter.dim_stop: dimmer_endpoint


### PR DESCRIPTION
### wifi-to-thread
For a wifi device to connect to a matter device, it needs have the route to the thread network (via the border router) in its routing table. The thread border router advertises this route via RA and lwIP is able to pick this route up with the `CONFIG_LWIP_IPV6_ND6_ROUTE_INFO_OPTION_SUPPORT` option enabled.

### wifi-to-wifi
Currently untested because I have no matter-over-wifi devices. Maybe I'll set up another esphome matter-over-wifi device and let them bind to each other.

### thread-to-thread
Not working and cause yet unknown. If thread-to-thread binding works, I think thread-to-wifi will also automatically work.