### PR TITLE
Add support for Climate components as Thermostat

### DIFF
--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -299,4 +299,8 @@ async def to_code(config: ConfigType):
     cg.add_build_flag("-DCHIP_CRYPTO_KEYSTORE_RAW=1")
 
     disable_unused_clusters()
+
+    if any(CONF_THERMOSTAT in ep for ep in config[CONF_ENDPOINTS]):
+        add_idf_sdkconfig_option("CONFIG_SUPPORT_THERMOSTAT_CLUSTER", True)
+
     await configure_endpoints(var, config)

--- a/components/matter/const.py
+++ b/components/matter/const.py
@@ -15,6 +15,10 @@ CONF_DIMMER_SWITCH = "dimmer_switch"
 # Sensors
 CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 
+# Climate
+CONF_THERMOSTAT = "thermostat"
+CONF_CLIMATE_ID = "climate_id"
+
 # Actions
 CONF_CLUSTER_ID = "cluster_id"
 CONF_COMMAND_ID = "command_id"

--- a/components/matter/endpoints.py
+++ b/components/matter/endpoints.py
@@ -1,7 +1,7 @@
 from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light, sensor
+from esphome.components import climate, light, sensor
 from esphome.const import (
     CONF_COMMAND,
     CONF_ID,
@@ -40,6 +40,12 @@ LIGHT_SCHEMA = cv.Schema(
     }
 )
 
+THERMOSTAT_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_CLIMATE_ID): cv.use_id(climate.Climate),
+    }
+)
+
 
 def _validate_endpoint(config):
     device_types = [k for k in config if k != CONF_ID]
@@ -62,6 +68,7 @@ ENDPOINT_SCHEMA = cv.All(
             cv.Optional(CONF_ON_OFF_SWITCH): ON_OFF_SWITCH_SCHEMA,
             cv.Optional(CONF_DIMMER_SWITCH): DIMMER_SWITCH_SCHEMA,
             cv.Optional(CONF_TEMPERATURE_SENSOR): TEMPERATURE_SENSOR_SCHEMA,
+            cv.Optional(CONF_THERMOSTAT): THERMOSTAT_SCHEMA,
             cv.Optional(CONF_ON_OFF_LIGHT): LIGHT_SCHEMA,
             cv.Optional(CONF_DIMMABLE_LIGHT): LIGHT_SCHEMA,
         }
@@ -81,6 +88,10 @@ async def configure_endpoints(var, config: ConfigType):
             opts = ep_conf[CONF_TEMPERATURE_SENSOR]
             sens = await cg.get_variable(opts[CONF_SENSOR_ID])
             cg.add(var.add_temperature_sensor(sens, ref))
+        elif CONF_THERMOSTAT in ep_conf:
+            opts = ep_conf[CONF_THERMOSTAT]
+            climate_var = await cg.get_variable(opts[CONF_CLIMATE_ID])
+            cg.add(var.add_thermostat(climate_var, ref))
         elif CONF_ON_OFF_LIGHT in ep_conf:
             light_var = await cg.get_variable(ep_conf[CONF_ON_OFF_LIGHT][CONF_LIGHT_ID])
             cg.add(var.add_on_off_light(light_var, ref))

--- a/components/matter/matter_component.h
+++ b/components/matter/matter_component.h
@@ -54,6 +54,19 @@ public:
     return nullptr;
   }
 #endif
+#ifdef USE_CLIMATE
+  void add_thermostat(climate::Climate *climate, MatterEndpointRef *ref) {
+    this->climates_.push_back(new MatterClimate(climate, ref));
+  }
+
+  MatterClimate *get_climate_by_endpoint(uint16_t endpoint_id) {
+    for (auto *mc : this->climates_) {
+      if (mc->endpoint_id == endpoint_id)
+        return mc;
+    }
+    return nullptr;
+  }
+#endif
   // Public wrapper around the protected Component scheduler; used by the
   // Matter-thread callbacks to hop onto the main loop (defer is thread-safe).
   void defer_to_main_loop(std::function<void()> &&f) {
@@ -74,6 +87,9 @@ private:
 #endif
 #ifdef USE_LIGHT
   std::vector<MatterLight *> lights_;
+#endif
+#ifdef USE_CLIMATE
+  std::vector<MatterClimate *> climates_;
 #endif
 };
 

--- a/components/matter/matter_endpoints.cpp
+++ b/components/matter/matter_endpoints.cpp
@@ -11,6 +11,7 @@ static const char *const TAG = "matter";
 
 namespace esphome::matter {
 
+#ifdef USE_CLIMATE
 namespace {
 
 struct ThermostatCapabilities {
@@ -67,6 +68,7 @@ uint8_t climate_mode_to_matter_mode(climate::ClimateMode mode) {
 }
 
 }  // namespace
+#endif  // USE_CLIMATE
 
 bool MatterComponent::create_endpoints_(esp_matter::node_t *node) {
   for (auto &sw : this->on_off_switches_) {

--- a/components/matter/matter_endpoints.cpp
+++ b/components/matter/matter_endpoints.cpp
@@ -11,6 +11,63 @@ static const char *const TAG = "matter";
 
 namespace esphome::matter {
 
+namespace {
+
+struct ThermostatCapabilities {
+  bool heating{false};
+  bool cooling{false};
+  bool auto_mode{false};
+};
+
+ThermostatCapabilities derive_thermostat_capabilities(
+    const climate::ClimateTraits &traits) {
+  const bool supports_heat_cool_mode =
+      traits.supports_mode(climate::CLIMATE_MODE_HEAT_COOL);
+
+  return {
+      .heating =
+          traits.supports_mode(climate::CLIMATE_MODE_HEAT) ||
+          supports_heat_cool_mode,
+      .cooling =
+          traits.supports_mode(climate::CLIMATE_MODE_COOL) ||
+          supports_heat_cool_mode,
+      .auto_mode =
+          traits.supports_mode(climate::CLIMATE_MODE_AUTO) ||
+          supports_heat_cool_mode,
+  };
+}
+
+int16_t celsius_to_matter_temperature(float temperature) {
+  return static_cast<int16_t>(std::lroundf(temperature * 100.0f));
+}
+
+uint8_t climate_mode_to_matter_mode(climate::ClimateMode mode) {
+  using Mode = chip::app::Clusters::Thermostat::SystemModeEnum;
+
+  switch (mode) {
+    case climate::CLIMATE_MODE_OFF:
+      return chip::to_underlying(Mode::kOff);
+    case climate::CLIMATE_MODE_COOL:
+      return chip::to_underlying(Mode::kCool);
+    case climate::CLIMATE_MODE_HEAT:
+      return chip::to_underlying(Mode::kHeat);
+    case climate::CLIMATE_MODE_AUTO:
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      // Matter Thermostat represents both ESPHome modes as SystemMode::Auto.
+      return chip::to_underlying(Mode::kAuto);
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      return chip::to_underlying(Mode::kFanOnly);
+    case climate::CLIMATE_MODE_DRY:
+      return chip::to_underlying(Mode::kDry);
+    default:
+      ESP_LOGW(TAG, "Unsupported ESPHome climate mode %u; mapping to Off",
+               static_cast<unsigned>(mode));
+      return chip::to_underlying(Mode::kOff);
+  }
+}
+
+}  // namespace
+
 bool MatterComponent::create_endpoints_(esp_matter::node_t *node) {
   for (auto &sw : this->on_off_switches_) {
     esp_matter::endpoint::on_off_light_switch::config_t sw_config;
@@ -79,10 +136,272 @@ bool MatterComponent::create_endpoints_(esp_matter::node_t *node) {
   }
 #endif
 
+#ifdef USE_CLIMATE
+  for (auto *mc : this->climates_) {
+    auto traits = mc->climate->get_traits();
+
+    esp_matter::endpoint::thermostat::config_t config;
+
+    const auto capabilities = derive_thermostat_capabilities(traits);
+
+    if (!capabilities.heating && !capabilities.cooling) {
+      ESP_LOGE(TAG,
+               "Cannot create Matter thermostat: ESPHome climate supports "
+               "neither heating nor cooling");
+      return false;
+    }
+
+    // Matter Thermostat ControlSequenceOfOperation:
+    // 0 = Cooling Only, 2 = Heating Only, 4 = Cooling and Heating.
+    config.thermostat.control_sequence_of_operation =
+        capabilities.heating && capabilities.cooling
+            ? 4
+            : (capabilities.heating ? 2 : 0);
+
+    // esp-matter requires Thermostat feature flags to be configured before
+    // endpoint::thermostat::create().
+    config.thermostat.feature_flags = 0;
+
+    if (capabilities.heating) {
+      config.thermostat.feature_flags |=
+          esp_matter::cluster::thermostat::feature::heating::get_id();
+    }
+
+    if (capabilities.cooling) {
+      config.thermostat.feature_flags |=
+          esp_matter::cluster::thermostat::feature::cooling::get_id();
+    }
+
+    // Matter AutoMode is only valid when both Heating and Cooling are present.
+    if (capabilities.auto_mode && capabilities.heating &&
+        capabilities.cooling) {
+      config.thermostat.feature_flags |=
+          esp_matter::cluster::thermostat::feature::auto_mode::get_id();
+    }
+
+    const float target_temperature = mc->climate->target_temperature;
+    if (!std::isnan(target_temperature)) {
+      const int16_t matter_target =
+          celsius_to_matter_temperature(target_temperature);
+
+      if (capabilities.heating) {
+        config.thermostat.features.heating.occupied_heating_setpoint =
+            matter_target;
+      }
+      if (capabilities.cooling) {
+        config.thermostat.features.cooling.occupied_cooling_setpoint =
+            matter_target;
+      }
+    }
+
+    const float current_temperature = mc->climate->current_temperature;
+    if (!std::isnan(current_temperature)) {
+      config.thermostat.local_temperature =
+          nullable<int16_t>(celsius_to_matter_temperature(current_temperature));
+    }
+
+    ESP_LOGD(TAG,
+             "Creating thermostat: heat=%s cool=%s auto=%s features=0x%08" PRIX32,
+             YESNO(capabilities.heating), YESNO(capabilities.cooling),
+             YESNO(capabilities.auto_mode),
+             config.thermostat.feature_flags);
+
+    esp_matter::endpoint_t *ep =
+        esp_matter::endpoint::thermostat::create(
+            node, &config, esp_matter::ENDPOINT_FLAG_NONE, nullptr);
+
+    if (ep == nullptr) {
+      ESP_LOGE(TAG, "Failed to create thermostat endpoint");
+      return false;
+    }
+
+    mc->endpoint_id = esp_matter::endpoint::get_id(ep);
+    mc->ref->endpoint_id = mc->endpoint_id;
+
+    ESP_LOGD(TAG, "Thermostat endpoint created: id=%u", mc->endpoint_id);
+  }
+#endif
+
   register_client_request_callbacks();
 
   return true;
 }
+
+#ifdef USE_CLIMATE
+
+void MatterClimate::push_state_to_matter() {
+  const uint16_t eid = this->endpoint_id;
+  const float current_temperature = this->climate->current_temperature;
+
+  const float target_temperature = this->climate->target_temperature;
+
+  const auto mode = this->climate->mode;
+
+  const uint8_t matter_mode = climate_mode_to_matter_mode(mode);
+
+  chip::DeviceLayer::SystemLayer().ScheduleLambda([eid, current_temperature,
+
+                                                   target_temperature, mode,
+                                                   matter_mode]() {
+    using namespace chip::app::Clusters;
+
+    //
+    // System mode
+    //
+    esp_matter_attr_val_t mode_val = esp_matter_enum8(matter_mode);
+
+    esp_matter::attribute::update(
+        eid, Thermostat::Id, Thermostat::Attributes::SystemMode::Id, &mode_val);
+
+    //
+    // Current temperature
+    //
+    const bool current_null = std::isnan(current_temperature);
+
+    int16_t current_raw =
+        current_null
+            ? 0
+            : celsius_to_matter_temperature(current_temperature);
+
+    esp_matter_attr_val_t current_val = esp_matter_nullable_int16(
+        current_null ? nullable<int16_t>() : nullable<int16_t>(current_raw));
+
+    esp_matter::attribute::update(eid, Thermostat::Id,
+                                  Thermostat::Attributes::LocalTemperature::Id,
+                                  &current_val);
+
+    if (std::isnan(target_temperature))
+      return;
+
+    int16_t target_raw =
+        celsius_to_matter_temperature(target_temperature);
+
+    esp_matter_attr_val_t target_val = esp_matter_int16(target_raw);
+
+    if (mode == climate::CLIMATE_MODE_HEAT) {
+      esp_matter::attribute::update(
+          eid, Thermostat::Id,
+          Thermostat::Attributes::OccupiedHeatingSetpoint::Id, &target_val);
+    } else {
+      //
+      // COOL, AUTO and the usual AC modes use the
+      // cooling setpoint for this first implementation.
+
+      //
+      esp_matter::attribute::update(
+          eid, Thermostat::Id,
+          Thermostat::Attributes::OccupiedCoolingSetpoint::Id, &target_val);
+    }
+  });
+}
+
+void MatterClimate::apply_matter_update(uint32_t cluster_id,
+                                        uint32_t attribute_id,
+                                        esp_matter_attr_val_t val) {
+
+  using namespace chip::app::Clusters;
+
+  if (cluster_id == Thermostat::Id) {
+    //
+    // HVAC mode
+    //
+    if (attribute_id == Thermostat::Attributes::SystemMode::Id) {
+
+      auto matter_mode = static_cast<Thermostat::SystemModeEnum>(val.val.u8);
+
+      climate::ClimateMode new_mode;
+
+      switch (matter_mode) {
+      case Thermostat::SystemModeEnum::kOff:
+        new_mode = climate::CLIMATE_MODE_OFF;
+        break;
+
+      case Thermostat::SystemModeEnum::kCool:
+        new_mode = climate::CLIMATE_MODE_COOL;
+        break;
+
+      case Thermostat::SystemModeEnum::kHeat:
+        new_mode = climate::CLIMATE_MODE_HEAT;
+        break;
+
+      case Thermostat::SystemModeEnum::kAuto:
+        new_mode = climate::CLIMATE_MODE_AUTO;
+        break;
+
+      case Thermostat::SystemModeEnum::kFanOnly:
+        new_mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+
+      case Thermostat::SystemModeEnum::kDry:
+        new_mode = climate::CLIMATE_MODE_DRY;
+        break;
+
+      default:
+        return;
+      }
+
+      auto traits = this->climate->get_traits();
+
+      //
+      // OFF is mandatory in ESPHome; reject Matter modes the
+      // underlying climate doesn't advertise.
+      //
+      if (new_mode != climate::CLIMATE_MODE_OFF &&
+          !traits.supports_mode(new_mode)) {
+
+        if (new_mode == climate::CLIMATE_MODE_AUTO &&
+            traits.supports_mode(climate::CLIMATE_MODE_HEAT_COOL)) {
+          new_mode = climate::CLIMATE_MODE_HEAT_COOL;
+        } else {
+          return;
+        }
+      }
+
+      if (this->climate->mode == new_mode)
+        return;
+
+      auto call = this->climate->make_call();
+      call.set_mode(new_mode);
+      call.perform();
+      return;
+    }
+
+    //
+    // Cooling setpoint
+    //
+    if (attribute_id == Thermostat::Attributes::OccupiedCoolingSetpoint::Id) {
+
+      const float temperature = static_cast<float>(val.val.i16) / 100.0f;
+
+      if (!std::isnan(this->climate->target_temperature) &&
+          std::fabs(this->climate->target_temperature - temperature) < 0.005f)
+        return;
+
+      auto call = this->climate->make_call();
+      call.set_target_temperature(temperature);
+      call.perform();
+      return;
+    }
+
+    //
+    // Heating setpoint
+    //
+    if (attribute_id == Thermostat::Attributes::OccupiedHeatingSetpoint::Id) {
+
+      const float temperature = static_cast<float>(val.val.i16) / 100.0f;
+
+      if (!std::isnan(this->climate->target_temperature) &&
+          std::fabs(this->climate->target_temperature - temperature) < 0.005f)
+        return;
+
+      auto call = this->climate->make_call();
+      call.set_target_temperature(temperature);
+      call.perform();
+    }
+  }
+}
+
+#endif // USE_CLIMATE
 
 #ifdef USE_LIGHT
 // Mirrors the current ESPHome light state to the Matter attributes.
@@ -148,21 +467,39 @@ endpoint_attribute_update_cb(esp_matter::attribute::callback_type_t type,
                              uint16_t endpoint_id, uint32_t cluster_id,
                              uint32_t attribute_id, esp_matter_attr_val_t *val,
                              void *priv_data) {
-#ifdef USE_LIGHT
+
   if (type != esp_matter::attribute::POST_UPDATE ||
       global_matter_component == nullptr)
     return ESP_OK;
-  MatterLight *ml = global_matter_component->get_light_by_endpoint(endpoint_id);
-  if (ml == nullptr)
+
+#ifdef USE_LIGHT
+  if (auto *ml = global_matter_component->get_light_by_endpoint(endpoint_id)) {
+
+    esp_matter_attr_val_t val_copy = *val;
+    global_matter_component->defer_to_main_loop(
+        [ml, cluster_id, attribute_id, val_copy]() {
+          ml->apply_matter_update(cluster_id, attribute_id, val_copy);
+        });
+
     return ESP_OK;
-  // This callback runs in the Matter thread; ESPHome entities are main-loop
-  // only.
-  esp_matter_attr_val_t val_copy = *val;
-  global_matter_component->defer_to_main_loop(
-      [ml, cluster_id, attribute_id, val_copy]() {
-        ml->apply_matter_update(cluster_id, attribute_id, val_copy);
-      });
+  }
 #endif
+
+#ifdef USE_CLIMATE
+  if (auto *mc =
+          global_matter_component->get_climate_by_endpoint(endpoint_id)) {
+
+    esp_matter_attr_val_t val_copy = *val;
+
+    global_matter_component->defer_to_main_loop(
+        [mc, cluster_id, attribute_id, val_copy]() {
+          mc->apply_matter_update(cluster_id, attribute_id, val_copy);
+        });
+
+    return ESP_OK;
+  }
+#endif
+
   return ESP_OK;
 }
 
@@ -198,6 +535,16 @@ void MatterComponent::register_endpoint_callbacks_() {
     ml->light->add_remote_values_listener(ml);
     ml->push_state_to_matter(); // initial sync so controllers read the real
                                 // state
+  }
+#endif
+
+#ifdef USE_CLIMATE
+  for (auto *mc : this->climates_) {
+    mc->climate->add_on_state_callback(
+      [mc](climate::Climate &) { mc->push_state_to_matter(); }
+    );
+
+  mc->push_state_to_matter();
   }
 #endif
 }

--- a/components/matter/matter_endpoints.h
+++ b/components/matter/matter_endpoints.h
@@ -6,6 +6,9 @@
 #ifdef USE_LIGHT
 #include "esphome/components/light/light_state.h"
 #endif
+#ifdef USE_CLIMATE
+#include "esphome/components/climate/climate.h"
+#endif
 
 #ifdef USE_MATTER
 
@@ -67,6 +70,26 @@ public:
   MatterEndpointRef *ref;
   uint16_t endpoint_id{0};
 };
+#endif
+
+#ifdef USE_CLIMATE
+
+class MatterClimate {
+ public:
+  MatterClimate(climate::Climate *climate, MatterEndpointRef *ref)
+      : climate(climate), ref(ref) {}
+
+  void push_state_to_matter();
+
+  void apply_matter_update(uint32_t cluster_id,
+                           uint32_t attribute_id,
+                           esp_matter_attr_val_t val);
+
+  climate::Climate *climate;
+  MatterEndpointRef *ref;
+  uint16_t endpoint_id{0};
+};
+
 #endif
 
 // Common esp_matter attribute update callback, passed to node::create().


### PR DESCRIPTION
I added my AC using Matter-over-WiFi using your project today, and this is what came out of it. I have verified it works with my device which is an Airmart AM105CDW duct system with an ESP32 hooked into it using the [esphome-haier](https://github.com/paveldn/haier-esphome) library. The code is pretty generic so I expect it would work for many other devices too.

The implementation is a new Matter thermostat endpoint backed by an ESPHome climate entity:

```yaml
matter:
  endpoints:
    - thermostat:
        climate_id: airmart_ac
        
climate:
  - platform: haier
    id: airmart_ac
    protocol: smartair2
    name: "Airmart AC"
    uart_id: ac_port
```

The current implementation maps:

- ESPHome current temperature → Matter Thermostat.LocalTemperature
- ESPHome target temperature → Matter heating/cooling setpoint
- ESPHome climate mode → Matter Thermostat.SystemMode
- Matter thermostat writes → ESPHome ClimateCall

Other notes:

- I experimented quite a bit with fan-speed support because the underlying ESPHome Haier climate exposes Auto / Low / Medium / High but I ultimately failed to make that work, at least not in a way Apple Home would show nicely.
- Besides the current Thermostat-based implementation, I also tested the "Room Air Conditioner" which also worked but the Thermostat presentation was the simplest approach for this device so I reverted to that.

I completely understand if you do not want to merge this, at least for now since the project is in its early stages. Feel free to close this PR too! I just hope you/we can add support for something like this over time.