### PR TITLE
esp-idf toolchain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ esphome:
   name: matter-device
 
 esp32:
-  toolchain: platformio
+  # The default toolchain in ESPHome is `esp-idf`. esphome-matter supports this
+  # toolchain starting at ESPHome version 2026.9.0. If you're still using an older
+  # version you need to set toolchain to platformio:
+  # toolchain: platformio
   variant: ESP32C6 # Set to your variant
   framework:
     type: esp-idf

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -96,7 +96,6 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,
     cv.only_with_framework(Framework.ESP_IDF),
-    _require_platformio_toolchain,
     _require_vfs_select,  # TODO: Only needed when openthread is enabled
 )
 
@@ -117,19 +116,6 @@ def _final_validate(_):
 FINAL_VALIDATE_SCHEMA = _final_validate
 
 
-# The esp32 component already sets board_build.cmake_extra_args at FINAL priority so we need
-# to set it after that to prevent this platformio option from being overwritten.
-@coroutine_with_priority(CoroPriority.FINAL - 1)
-async def _set_executable_component_name():
-    # esp_matter's CMakeLists.txt defaults EXECUTABLE_COMPONENT_NAME to "main", but ESPHome names
-    # the app component "src".
-    if CORE.using_toolchain_platformio:
-        key = "board_build.cmake_extra_args"
-        value = CORE.platformio_options.get(key, "")
-        value += " -DEXECUTABLE_COMPONENT_NAME=src"
-        cg.add_platformio_option(key, value)
-
-
 @coroutine_with_priority(CoroPriority.NETWORK_SERVICES)
 async def to_code(config: ConfigType):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -140,8 +126,6 @@ async def to_code(config: ConfigType):
         ref="1.5.1",
     )
 
-    CORE.add_job(_set_executable_component_name)
-
     cg.add_define("USE_MATTER")
     cg.add_build_flag(
         f'-DCHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME=\\"{config[CONF_VENDOR_NAME]}\\"'
@@ -149,6 +133,10 @@ async def to_code(config: ConfigType):
     cg.add_build_flag(
         f'-DCHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME=\\"{config[CONF_PRODUCT_NAME]}\\"'
     )
+
+    # esp-matter's CMakeLists.txt defaults EXECUTABLE_COMPONENT_NAME to "main", but ESPHome names
+    # the component "src".
+    cg.add_cmake_arg("EXECUTABLE_COMPONENT_NAME", "src")
 
     if CONF_DISCRIMINATOR in config:
         cg.add_define("MATTER_DISCRIMINATOR", config[CONF_DISCRIMINATOR])

--- a/components/matter/__init__.py
+++ b/components/matter/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_ENABLE_IPV6,
     CONF_ID,
     Framework,
+    __version__ as ESPHOME_VERSION,
 )
 from esphome.core import CORE
 from esphome.coroutine import CoroPriority, coroutine_with_priority
@@ -28,8 +29,8 @@ CODEOWNERS = ["@DavidvtWout"]
 
 AUTO_LOAD = ["network"]
 
-# Only for matter-over-thread
-MIN_ESPHOME_VERSION = "2026.6.0"
+MIN_ESPHOME_THREAD_VERSION = "2026.6.0"
+MIN_ESPHOME_IDF_TOOLCHAIN_VERSION = "2026.9.0"
 
 # Matter spec section 5.1.7.1: these passcodes are explicitly forbidden.
 _FORBIDDEN_PASSCODES = {
@@ -103,7 +104,9 @@ CONFIG_SCHEMA = cv.All(
 def _final_validate(_):
     full_config = fv.full_config.get()
     if "openthread" in full_config:
-        cv.validate_esphome_version(MIN_ESPHOME_VERSION)
+        cv.validate_esphome_version(MIN_ESPHOME_THREAD_VERSION)
+    if CORE.using_toolchain_esp_idf:
+        cv.validate_esphome_version(MIN_ESPHOME_IDF_TOOLCHAIN_VERSION)
 
     network_config = full_config.get("network", {})
     if not network_config.get(CONF_ENABLE_IPV6, False):
@@ -114,6 +117,19 @@ def _final_validate(_):
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+# The esp32 component already sets board_build.cmake_extra_args at FINAL priority so we need
+# to set it after that to prevent this platformio option from being overwritten.
+@coroutine_with_priority(CoroPriority.FINAL - 1)
+async def _set_executable_component_name():
+    # esp_matter's CMakeLists.txt defaults EXECUTABLE_COMPONENT_NAME to "main", but ESPHome names
+    # the app component "src".
+    if CORE.using_toolchain_platformio:
+        key = "board_build.cmake_extra_args"
+        value = CORE.platformio_options.get(key, "")
+        value += " -DEXECUTABLE_COMPONENT_NAME=src"
+        cg.add_platformio_option(key, value)
 
 
 @coroutine_with_priority(CoroPriority.NETWORK_SERVICES)
@@ -134,9 +150,12 @@ async def to_code(config: ConfigType):
         f'-DCHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME=\\"{config[CONF_PRODUCT_NAME]}\\"'
     )
 
-    # esp-matter's CMakeLists.txt defaults EXECUTABLE_COMPONENT_NAME to "main", but ESPHome names
-    # the component "src".
-    cg.add_cmake_arg("EXECUTABLE_COMPONENT_NAME", "src")
+    # esp_matter's CMakeLists.txt defaults EXECUTABLE_COMPONENT_NAME to "main", but ESPHome
+    # names the app component "src".
+    try:
+        cg.add_cmake_arg("EXECUTABLE_COMPONENT_NAME", "src")
+    except AttributeError:
+        CORE.add_job(_set_executable_component_name)
 
     if CONF_DISCRIMINATOR in config:
         cg.add_define("MATTER_DISCRIMINATOR", config[CONF_DISCRIMINATOR])

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785967620,
-        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,31 @@
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
+
+      esphome-cmake-args = pkgs.esphome.overridePythonAttrs (old: {
+        version = "2026.9.0-dev";
+        src = pkgs.fetchFromGitHub {
+          owner = "DavidvtWout";
+          repo = "esphome";
+          rev = "cmake-args";
+          hash = "sha256-P+9pu8NIlO+93mi7znOjCYnXwIsb4CjGaejOAwaConI=";
+        };
+        postPatch = ''
+          substituteInPlace pyproject.toml \
+            --replace-fail "setuptools==84.0.0" "setuptools" \
+            --replace-fail "wheel>=0.43,<0.48" "wheel"
+        '';
+        patches = [ ];
+        dependencies =
+          old.dependencies
+          ++ (with pkgs.python3.pkgs; [
+            (toPythonModule pkgs.platformio-core)
+            filelock
+            platformdirs
+          ]);
+        doCheck = false;
+      });
+
       preCommitCheck = pre-commit-hooks.lib.${system}.run {
         src = ./.;
         hooks.clang-format.enable = true;
@@ -20,9 +45,10 @@
     in
     {
       checks.${system}.pre-commit = preCommitCheck;
+      formatter.${system} = pkgs.nixfmt;
 
       devShells.${system}.default = pkgs.mkShell {
-        packages = with pkgs; [ esphome ];
+        packages = [ esphome-cmake-args ];
         shellHook = preCommitCheck.shellHook;
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -12,18 +12,18 @@
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
 
-      esphome-cmake-args = pkgs.esphome.overridePythonAttrs (old: {
+      my-esphome = pkgs.esphome.overridePythonAttrs (old: {
         version = "2026.9.0-dev";
         src = pkgs.fetchFromGitHub {
           owner = "DavidvtWout";
           repo = "esphome";
-          rev = "cmake-args";
-          hash = "sha256-P+9pu8NIlO+93mi7znOjCYnXwIsb4CjGaejOAwaConI=";
+          rev = "openthread-logging";
+          hash = "sha256-562z9kapaLXEIcHK8OwFZwRXF39sGAmeWMSRP22DQ6w=";
         };
         postPatch = ''
           substituteInPlace pyproject.toml \
             --replace-fail "setuptools==84.0.0" "setuptools" \
-            --replace-fail "wheel>=0.43,<0.48" "wheel"
+            --replace-fail "wheel>=0.43,<0.49" "wheel"
         '';
         patches = [ ];
         dependencies =
@@ -48,7 +48,10 @@
       formatter.${system} = pkgs.nixfmt;
 
       devShells.${system}.default = pkgs.mkShell {
-        packages = [ esphome-cmake-args ];
+        packages = with pkgs; [
+          my-esphome
+          esptool
+        ];
         shellHook = preCommitCheck.shellHook;
       };
     };


### PR DESCRIPTION
[https://github.com/esphome/esphome/pull/18498](https://github.com/esphome/esphome/pull/18498) is now merged into ESPHome. When the first version is released that contrains `gc.add_cmake_arg`, this PR can also be merged. It's likely going to be 2026.9.0.

- [ ] Test build with actual esphome release from [pypi](https://pypi.org/project/esphome).